### PR TITLE
Animate colors and values in the bet tables when odds change

### DIFF
--- a/src/app/__tests__/ArenaTableBody.customOdds.test.tsx
+++ b/src/app/__tests__/ArenaTableBody.customOdds.test.tsx
@@ -74,8 +74,13 @@ describe('ArenaTableBody Payout cell vs Custom Odds', () => {
     const percentCellsBefore = rowBefore.querySelectorAll('td');
     // Column order (Big Brain, Logit model, Custom Odds mode off) is:
     // [pirate name, Prob%, Payout%, FA, ...]. Take the 2nd '%' cell (Payout).
+    // Payout renders via AnimatedNumber, which tweens its visible text on a rAF
+    // loop, so read the span's aria-label (always the final formatted value)
+    // rather than textContent (which lags behind mid-tween).
+    const getPercentText = (td: Element): string | null | undefined =>
+      td.querySelector('span[aria-label]')?.getAttribute('aria-label') ?? td.textContent;
     const payoutTextBefore = Array.from(percentCellsBefore)
-      .map(td => td.textContent)
+      .map(getPercentText)
       .filter(text => text?.includes('%'))[1];
 
     // Now enable Custom Odds mode with a value for pirate 1 (index 0) in arena 0
@@ -98,7 +103,7 @@ describe('ArenaTableBody Payout cell vs Custom Odds', () => {
     // Column order now includes the Custom Prob input before Payout, but
     // that's a NumberInput (no '%' text node), so Payout is still the 2nd match.
     const payoutTextAfter = Array.from(percentCellsAfter)
-      .map(td => td.textContent)
+      .map(getPercentText)
       .filter(text => text?.includes('%'))[1];
 
     expect(payoutTextAfter).not.toBe(payoutTextBefore);

--- a/src/app/components/tables/ArenaTableBody.tsx
+++ b/src/app/components/tables/ArenaTableBody.tsx
@@ -686,7 +686,7 @@ const PirateRow = React.memo(
           textAlign="end"
           {...(payoutBackground && { layerStyle: 'fill.subtle', colorPalette: payoutBackground })}
         >
-          {displayAsPercent(payout, 1)}
+          <AnimatedNumber value={payout} format={v => displayAsPercent(v, 1)} />
         </Td>
       );
     }, [payout, payoutBackground, bigBrain]);

--- a/src/app/components/tables/ArenaTableBody.tsx
+++ b/src/app/components/tables/ArenaTableBody.tsx
@@ -56,6 +56,7 @@ import CustomOddsInput from '../bets/CustomOddsInput';
 import CustomProbsInput from '../bets/CustomProbsInput';
 import PirateSelect from '../bets/PirateSelect';
 import OddsTimeline from '../timeline/OddsTimeline';
+import AnimatedNumber from '../ui/AnimatedNumber';
 import FaDetailsElement from '../ui/FaDetailsElement';
 import TextTooltip from '../ui/TextTooltip';
 
@@ -740,11 +741,19 @@ const PirateRow = React.memo(
         >
           <Box display="flex" alignItems="center" justifyContent="flex-end">
             {oddsChanged && (
-              <Icon color={oddsIncreased ? 'nfc-green.fg' : 'nfc-red.fg'} mr={1}>
-                {oddsIncreased ? <FaCaretUp /> : <FaCaretDown />}
-              </Icon>
+              <Box
+                key={`${currentOdds}-${oddsIncreased ? 'up' : 'down'}`}
+                animation="odds-arrow-in 0.3s ease-out"
+              >
+                <Icon color={oddsIncreased ? 'nfc-green.fg' : 'nfc-red.fg'} mr={1}>
+                  {oddsIncreased ? <FaCaretUp /> : <FaCaretDown />}
+                </Icon>
+              </Box>
             )}
-            <Text fontWeight={oddsChanged ? 'bold' : 'normal'}>{currentOdds}:1</Text>
+            <Text fontWeight={oddsChanged ? 'bold' : 'normal'}>
+              <AnimatedNumber value={currentOdds!} />
+              :1
+            </Text>
           </Box>
         </Td>
         {customOddsInputElement}

--- a/src/app/components/tables/DropDownTable.tsx
+++ b/src/app/components/tables/DropDownTable.tsx
@@ -22,6 +22,7 @@ import { displayAsPercent } from '../../util';
 import { computeDuplicateBetGroupColors } from '../../utils/duplicateBetColors';
 import ClearBetsButton from '../bets/ClearBetsButton';
 import PirateSelect from '../bets/PirateSelect';
+import AnimatedNumber from '../ui/AnimatedNumber';
 
 import Td from './Td';
 
@@ -140,7 +141,10 @@ const PirateInfoRow = React.memo(
         </Td>
         <Td style={{ textAlign: 'end' }}>{opening}:1</Td>
         <Td style={{ textAlign: 'end' }}>
-          <Text fontWeight={current === opening ? 'normal' : 'bold'}>{current}:1</Text>
+          <Text fontWeight={current === opening ? 'normal' : 'bold'}>
+            <AnimatedNumber value={current} />
+            :1
+          </Text>
         </Td>
       </Table.Row>
     );

--- a/src/app/components/tables/PayoutTable.tsx
+++ b/src/app/components/tables/PayoutTable.tsx
@@ -39,6 +39,7 @@ import {
 import { displayAsPercent, displayAsPercentSmart, getMaxSmartPercentDecimals } from '../../util';
 import BetAmountInput from '../bets/BetAmountInput';
 import PlaceThisBetButton from '../bets/PlaceThisBetButton';
+import AnimatedNumber from '../ui/AnimatedNumber';
 import TextTooltip from '../ui/TextTooltip';
 
 import Td from './Td';
@@ -194,7 +195,12 @@ const PayoutTableRow = React.memo(
 
     const probabilityTooltip = useMemo(
       () => ({
-        text: displayAsPercent(probabilities, probabilityDecimals),
+        text: (
+          <AnimatedNumber
+            value={probabilities}
+            format={v => displayAsPercent(v, probabilityDecimals)}
+          />
+        ),
         label: displayAsPercentSmart(probabilities),
       }),
       [probabilities, probabilityDecimals],
@@ -202,7 +208,12 @@ const PayoutTableRow = React.memo(
 
     const expectedRatioTooltip = useMemo(
       () => ({
-        text: `${er.toFixed(3)}:1`,
+        text: (
+          <>
+            <AnimatedNumber value={er} format={v => v.toFixed(3)} />
+            :1
+          </>
+        ),
         label: er.toString(),
       }),
       [er],
@@ -210,7 +221,14 @@ const PayoutTableRow = React.memo(
 
     const netExpectedTooltip = useMemo(
       () => ({
-        text: ne.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
+        text: (
+          <AnimatedNumber
+            value={ne}
+            format={v =>
+              v.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+            }
+          />
+        ),
         label: ne.toString(),
       }),
       [ne],
@@ -298,10 +316,12 @@ const PayoutTableRow = React.memo(
           />
         </Td>
         <Td style={{ textAlign: 'end' }}>
-          {odds?.toLocaleString() ?? '0'}
+          <AnimatedNumber value={odds ?? 0} />
           :1
         </Td>
-        <Td style={{ textAlign: 'end' }}>{payoffs?.toLocaleString() ?? '0'}</Td>
+        <Td style={{ textAlign: 'end' }}>
+          <AnimatedNumber value={payoffs ?? 0} />
+        </Td>
         <Td style={{ textAlign: 'end' }}>
           <MemoizedTextTooltip text={probabilityTooltip.text} content={probabilityTooltip.label} />
         </Td>
@@ -327,7 +347,7 @@ const PayoutTableRow = React.memo(
           {mbBg ? (
             <TextTooltip
               placement="top"
-              text={maxBets?.toLocaleString() ?? '0'}
+              text={<AnimatedNumber value={maxBets ?? 0} />}
               content={
                 mbBg === 'nfc-yellow'
                   ? 'Bet amount is 1 NP over maxbet'
@@ -337,7 +357,7 @@ const PayoutTableRow = React.memo(
               textDecoration="underline dotted"
             />
           ) : (
-            (maxBets?.toLocaleString() ?? '0')
+            <AnimatedNumber value={maxBets ?? 0} />
           )}
         </Td>
         {[0, 1, 2, 3, 4].map(arenaIndex => {
@@ -424,7 +444,7 @@ const PayoutTable = React.memo((): React.ReactElement => {
 
   const totalExpectedRatioTooltip = useMemo(
     () => ({
-      text: totalBetExpectedRatios.toFixed(3),
+      text: <AnimatedNumber value={totalBetExpectedRatios} format={v => v.toFixed(3)} />,
       label: totalBetExpectedRatios.toString(),
     }),
     [totalBetExpectedRatios],
@@ -432,10 +452,14 @@ const PayoutTable = React.memo((): React.ReactElement => {
 
   const totalNetExpectedTooltip = useMemo(
     () => ({
-      text: totalBetNetExpected.toLocaleString(undefined, {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      }),
+      text: (
+        <AnimatedNumber
+          value={totalBetNetExpected}
+          format={v =>
+            v.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+          }
+        />
+      ),
       label: totalBetNetExpected.toString(),
     }),
     [totalBetNetExpected],
@@ -482,12 +506,16 @@ const PayoutTable = React.memo((): React.ReactElement => {
               <Table.ColumnHeader style={{ textAlign: 'end' }}>
                 {winningBetBinary > 0 && (
                   <Text>
-                    {totalWinningOdds.toLocaleString()}:{totalEnabledBets}
+                    <AnimatedNumber value={totalWinningOdds} />:{totalEnabledBets}
                   </Text>
                 )}
               </Table.ColumnHeader>
               <Table.ColumnHeader style={{ textAlign: 'end' }}>
-                {winningBetBinary > 0 && <Text>{totalWinningPayoff.toLocaleString()}</Text>}
+                {winningBetBinary > 0 && (
+                  <Text>
+                    <AnimatedNumber value={totalWinningPayoff} />
+                  </Text>
+                )}
               </Table.ColumnHeader>
               <Table.ColumnHeader style={{ textAlign: 'end' }} />
               <Table.ColumnHeader

--- a/src/app/components/ui/AnimatedNumber.tsx
+++ b/src/app/components/ui/AnimatedNumber.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+// this element displays a number that smoothly tweens (counts) from its
+// previous value to a new one whenever the value changes, using an
+// ease-out-cubic requestAnimationFrame loop. The animation is interruptible:
+// if a new value arrives mid-tween, it retargets from the currently displayed
+// value so rapid successive updates (e.g. odds changing every poll) stay smooth.
+
+interface AnimatedNumberProps {
+  value: number;
+  format?: (value: number) => string;
+  durationMs?: number;
+  className?: string;
+}
+
+const easeOutCubic = (t: number): number => 1 - Math.pow(1 - t, 3);
+
+const AnimatedNumber = React.memo(
+  ({ value, format, durationMs = 400, className }: AnimatedNumberProps): React.ReactElement => {
+    const [displayed, setDisplayed] = useState(value);
+    const displayedRef = useRef(value);
+    const frameRef = useRef<number | null>(null);
+
+    useEffect(() => {
+      displayedRef.current = displayed;
+    });
+
+    useEffect(() => {
+      if (frameRef.current !== null) {
+        window.cancelAnimationFrame(frameRef.current);
+        frameRef.current = null;
+      }
+
+      const prefersReducedMotion =
+        typeof window !== 'undefined' &&
+        typeof window.matchMedia === 'function' &&
+        window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+      const from = displayedRef.current;
+
+      if (prefersReducedMotion || value === from || durationMs <= 0) {
+        displayedRef.current = value;
+        setDisplayed(value);
+        return;
+      }
+
+      const start = window.performance.now();
+
+      const tick = (now: number): void => {
+        const t = Math.min(1, (now - start) / durationMs);
+        const next = from + (value - from) * easeOutCubic(t);
+        displayedRef.current = next;
+        setDisplayed(next);
+        if (t < 1) {
+          frameRef.current = window.requestAnimationFrame(tick);
+        } else {
+          frameRef.current = null;
+          displayedRef.current = value;
+          setDisplayed(value);
+        }
+      };
+
+      frameRef.current = window.requestAnimationFrame(tick);
+
+      return (): void => {
+        if (frameRef.current !== null) {
+          window.cancelAnimationFrame(frameRef.current);
+          frameRef.current = null;
+        }
+      };
+    }, [value, durationMs]);
+
+    const formatter = format ?? ((v: number): string => v.toLocaleString());
+
+    return (
+      <span className={className} aria-label={formatter(value)}>
+        {formatter(displayed)}
+      </span>
+    );
+  },
+);
+
+AnimatedNumber.displayName = 'AnimatedNumber';
+
+export default AnimatedNumber;

--- a/src/app/components/ui/__tests__/AnimatedNumber.test.tsx
+++ b/src/app/components/ui/__tests__/AnimatedNumber.test.tsx
@@ -1,0 +1,115 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AnimatedNumber from '../AnimatedNumber';
+
+describe('AnimatedNumber', () => {
+  let rafQueue: { id: number; cb: (now: number) => void }[];
+  let nextRafId: number;
+  let now: number;
+
+  beforeEach(() => {
+    rafQueue = [];
+    nextRafId = 1;
+    now = 0;
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((cb: (t: number) => void) => {
+        const id = nextRafId++;
+        rafQueue.push({ id, cb });
+        return id;
+      }),
+    );
+    vi.stubGlobal(
+      'cancelAnimationFrame',
+      vi.fn((id: number) => {
+        rafQueue = rafQueue.filter(entry => entry.id !== id);
+      }),
+    );
+    vi.stubGlobal('performance', { now: () => now });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const flushFrames = (duration: number, step = 16): void => {
+    const until = now + duration;
+    act(() => {
+      while (now < until && rafQueue.length > 0) {
+        const frame = rafQueue.shift()!;
+        now += step;
+        frame.cb(now);
+      }
+    });
+  };
+
+  it('renders the initial value without animating', () => {
+    render(<AnimatedNumber value={42} />);
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(rafQueue).toHaveLength(0);
+  });
+
+  it('tweens from the previous value to the new value', () => {
+    const { rerender } = render(<AnimatedNumber value={20} />);
+    rerender(<AnimatedNumber value={24} />);
+
+    expect(rafQueue.length).toBeGreaterThan(0);
+    expect(screen.queryByText('24')).not.toBeInTheDocument();
+
+    flushFrames(400);
+    expect(screen.getByText('24')).toBeInTheDocument();
+    expect(rafQueue).toHaveLength(0);
+  });
+
+  it('shows intermediate values mid-tween', () => {
+    const { rerender } = render(<AnimatedNumber value={20} />);
+    rerender(<AnimatedNumber value={24} />);
+
+    act(() => {
+      const frame = rafQueue.shift()!;
+      now += 16;
+      frame.cb(now);
+    });
+    const mid = Number(screen.getByText(/2[0-4]/).textContent);
+    expect(mid).toBeGreaterThan(20);
+    expect(mid).toBeLessThan(24);
+  });
+
+  it('retargets from the currently displayed value when interrupted', () => {
+    const { rerender } = render(<AnimatedNumber value={20} />);
+    rerender(<AnimatedNumber value={24} />);
+    flushFrames(200); // partway toward 24
+
+    rerender(<AnimatedNumber value={22} />);
+    flushFrames(400);
+    expect(screen.getByText('22')).toBeInTheDocument();
+  });
+
+  it('uses the custom format function', () => {
+    render(<AnimatedNumber value={1234.5} format={v => `${v.toFixed(2)}%`} />);
+    expect(screen.getByText('1234.50%')).toBeInTheDocument();
+  });
+
+  it('jumps instantly when prefers-reduced-motion is set', () => {
+    vi.spyOn(window, 'matchMedia').mockImplementation(
+      query =>
+        ({
+          matches: query === '(prefers-reduced-motion: reduce)',
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        }) as unknown as MediaQueryList,
+    );
+
+    const { rerender } = render(<AnimatedNumber value={20} />);
+    rerender(<AnimatedNumber value={24} />);
+    expect(screen.getByText('24')).toBeInTheDocument();
+    expect(rafQueue).toHaveLength(0);
+    vi.restoreAllMocks();
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,25 @@ body {
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
+
+/* Smoothly cross-fade table cell colors (e.g. red <-> green) when odds change.
+   Chakra writes backgrounds as inline styles, so !important is required for the
+   transition shorthand to win. Scoped to table cells only. */
+td,
+th {
+  transition:
+    background-color 0.6s ease,
+    color 0.6s ease !important;
+}
+
+/* Ease-in for the up/down arrow next to a changed current odds value. */
+@keyframes odds-arrow-in {
+  from {
+    opacity: 0;
+    transform: translateY(2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
## Summary
- Cross-fade table cell background/color transitions globally (td/th) instead of hard-cutting on the ~10s odds poll
- Add an AnimatedNumber component that tweens numeric values (rAF, ease-out-cubic, ~400ms, interruptible mid-tween, respects prefers-reduced-motion) instead of jumping
- Wire it into the main pirate table (current odds + arrow indicator), the payout table (Odds/Payoff/Maxbet/Prob/E.R./N.E. and totals), and the dropdown table (current odds per pirate)
- Up/down arrow next to current odds now fades/slides in instead of popping