### PR TITLE
Move round selection from dev drawer into View Round JSON modal

### DIFF
--- a/src/app/components/dev/DevModeDrawer.tsx
+++ b/src/app/components/dev/DevModeDrawer.tsx
@@ -1,12 +1,10 @@
-import { Button, Drawer, Portal, Stack, CloseButton, Text, Separator } from '@chakra-ui/react';
+import { Button, Drawer, Portal, Stack, CloseButton, Separator } from '@chakra-ui/react';
 import * as React from 'react';
 import { FaBalanceScale, FaCode, FaTable } from 'react-icons/fa';
 import { FaMagnifyingGlassChart } from 'react-icons/fa6';
 
 import { useDisclosureState } from '../../hooks/useDisclosureState';
-import { useCurrentRound } from '../../stores';
 import { getReactScanEnabled, setReactScanEnabled } from '../../util/reactScan';
-import RoundInput from '../inputs/RoundInput';
 import { AllBetsModal } from '../modals/AllBetsModal';
 import { BacktestComparisonModal } from '../modals/BacktestComparisonModal';
 import { RoundJsonModal } from '../modals/RoundJsonModal';
@@ -21,7 +19,6 @@ export const DevModeDrawer: React.FC<DevModeDrawerProps> = ({ isOpen, onClose })
   const jsonModal = useDisclosureState(false);
   const allBetsModal = useDisclosureState(false);
   const backtestModal = useDisclosureState(false);
-  const currentRoundFromCdn = useCurrentRound();
   const [isReactScanEnabled, setIsReactScanEnabled] = React.useState(getReactScanEnabled);
 
   const handleReactScanToggle = React.useCallback((): void => {
@@ -52,17 +49,6 @@ export const DevModeDrawer: React.FC<DevModeDrawerProps> = ({ isOpen, onClose })
               </Drawer.Header>
               <Drawer.Body>
                 <Stack gap={3}>
-                  <Stack gap={1} align="stretch">
-                    <Text fontSize="sm" fontWeight="medium">
-                      Change round
-                    </Text>
-                    <Text fontSize="xs" color="fg.muted">
-                      Current round on Neopets:{' '}
-                      {currentRoundFromCdn > 0 ? currentRoundFromCdn : '—'}
-                    </Text>
-                    <RoundInput />
-                  </Stack>
-                  <Separator />
                   <SettingsSwitch
                     icon={FaMagnifyingGlassChart}
                     label="React Scan"

--- a/src/app/components/inputs/RoundInput.tsx
+++ b/src/app/components/inputs/RoundInput.tsx
@@ -14,20 +14,40 @@ import {
 // Hook to get error state from the store
 const useErrorState = (): string | null => useRoundStore(state => state.error);
 
+interface RoundInputProps {
+  /** Displayed round; falls back to the store's `currentSelectedRound` when omitted. */
+  selectedRound?: number;
+  /** Round to revert to on empty/invalid input; falls back to the store's `currentRound`. */
+  referenceRound?: number;
+  /** Called with the debounced-commit round instead of the store's `updateSelectedRound`. */
+  onRoundChange?: (round: number) => void;
+  /** Falls back to the store's error state when omitted. */
+  hasError?: boolean;
+}
+
 // this element is the number input to say which round's data you're viewing
 
-const RoundInput: React.FC = () => {
-  const currentSelectedRound = useRoundStore(state => state.currentSelectedRound);
-  const currentRound = useRoundStore(state => state.currentRound);
+const RoundInput: React.FC<RoundInputProps> = ({
+  selectedRound,
+  referenceRound,
+  onRoundChange,
+  hasError: hasErrorProp,
+}) => {
+  const storeSelectedRound = useRoundStore(state => state.currentSelectedRound);
+  const storeCurrentRound = useRoundStore(state => state.currentRound);
   const updateSelectedRound = useRoundStore(state => state.updateSelectedRound);
-  const error = useErrorState();
+  const storeError = useErrorState();
+
+  const currentSelectedRound = selectedRound ?? storeSelectedRound;
+  const currentRound = referenceRound ?? storeCurrentRound;
+  const commitRound = onRoundChange ?? updateSelectedRound;
 
   const initialRoundNumber = useMemo(() => currentSelectedRound || 0, [currentSelectedRound]);
 
   const [tempValue, setTempValue] = useState<string>(() => initialRoundNumber.toString());
 
   // Check if there's an error related to the current round
-  const hasError = Boolean(error);
+  const hasError = hasErrorProp ?? Boolean(storeError);
 
   // Use custom hook to handle debouncing with cancellation on external changes
   useDebouncedRoundInput(
@@ -51,10 +71,9 @@ const RoundInput: React.FC = () => {
           return;
         }
 
-        // Use the new updateSelectedRound action which handles data fetching automatically
-        updateSelectedRound(roundNumber);
+        commitRound(roundNumber);
       },
-      [currentSelectedRound, updateSelectedRound],
+      [currentSelectedRound, commitRound],
     ),
   );
 

--- a/src/app/components/modals/RoundJsonModal.tsx
+++ b/src/app/components/modals/RoundJsonModal.tsx
@@ -237,12 +237,8 @@ export const RoundJsonModal: React.FC<RoundJsonModalProps> = ({ isOpen, onClose 
                     hasError={previewError !== null}
                   />
                 </Stack>
-                <Box minH="300px">
-                  {previewLoading ? (
-                    <Text fontSize="sm" color="fg.muted">
-                      Loading round {previewRound}...
-                    </Text>
-                  ) : previewError ? (
+                <Box minH="300px" opacity={previewLoading ? 0.6 : 1} transition="opacity 0.15s">
+                  {previewError ? (
                     <Text fontSize="sm" color="nfc-red.fg">
                       {previewError}
                     </Text>

--- a/src/app/components/modals/RoundJsonModal.tsx
+++ b/src/app/components/modals/RoundJsonModal.tsx
@@ -16,8 +16,11 @@ import * as React from 'react';
 import { FaCode } from 'react-icons/fa';
 import type { HighlighterGeneric } from 'shiki';
 
+import { defaultRoundData } from '../../constants';
 import { useCurrentRound, useRoundStore } from '../../stores';
 import RoundInput from '../inputs/RoundInput';
+
+import { RoundData } from '@/types';
 
 // Uses the fine-grained core API (rather than `createHighlighter` from the
 // `shiki` package) so the bundler only includes the json language and
@@ -129,10 +132,76 @@ const formatJsonWithDepth = (
 
 export const RoundJsonModal: React.FC<RoundJsonModalProps> = ({ isOpen, onClose }) => {
   const roundData = useRoundStore(state => state.roundData);
+  const currentSelectedRound = useRoundStore(state => state.currentSelectedRound);
   const currentRoundFromCdn = useCurrentRound();
 
+  // The round being previewed in this modal - independent of the globally
+  // selected round, so typing here never touches the rest of the page.
+  const [previewRound, setPreviewRound] = React.useState(0);
+  const [previewData, setPreviewData] = React.useState<RoundData | null>(null);
+  const [previewLoading, setPreviewLoading] = React.useState(false);
+  const [previewError, setPreviewError] = React.useState<string | null>(null);
+
+  // Reset the preview to the live round each time the modal opens. Runs as a
+  // layout effect so the reset is committed before the fetch effect below
+  // sees `previewRound` in this same pass - otherwise the fetch effect would
+  // briefly run once more against the stale (pre-reset) round.
+  React.useLayoutEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    setPreviewRound(currentSelectedRound);
+    setPreviewData(null);
+    setPreviewError(null);
+  }, [isOpen, currentSelectedRound]);
+
+  // Fetch the previewed round's JSON directly - bypassing the round store
+  // entirely - whenever it differs from the round already loaded globally.
+  React.useEffect(() => {
+    if (!isOpen || previewRound === 0 || previewRound === roundData.round) {
+      // Nothing to fetch - make sure a stale loading/error state from a
+      // previous (now-superseded) preview round doesn't linger.
+      setPreviewLoading(false);
+      setPreviewError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    setPreviewLoading(true);
+    setPreviewError(null);
+
+    fetch(`https://cdn.neofood.club/rounds/${previewRound}.json`, {
+      signal: controller.signal,
+    })
+      .then(response => {
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        return response.json() as Promise<RoundData>;
+      })
+      .then(data => {
+        setPreviewData(data);
+        setPreviewLoading(false);
+      })
+      .catch(error => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        console.error(`Failed to fetch round ${previewRound}:`, error);
+        setPreviewError(`Failed to fetch round ${previewRound}`);
+        setPreviewLoading(false);
+      });
+
+    return (): void => controller.abort();
+  }, [isOpen, previewRound, roundData.round]);
+
+  const isPreviewingLoadedRound = previewRound === roundData.round;
+  const displayedRoundData = isPreviewingLoadedRound
+    ? roundData
+    : (previewData ?? defaultRoundData);
+
   // Pretty-format the JSON with depth limit and special case for winners
-  const formattedJson = formatJsonWithDepth(roundData, 2, ['winners']);
+  const formattedJson = formatJsonWithDepth(displayedRoundData, 2, ['winners']);
 
   return (
     <Dialog.Root
@@ -160,33 +229,48 @@ export const RoundJsonModal: React.FC<RoundJsonModalProps> = ({ isOpen, onClose 
                   <Text fontSize="xs" color="fg.muted">
                     Current round on Neopets: {currentRoundFromCdn > 0 ? currentRoundFromCdn : '—'}
                   </Text>
-                  <RoundInput />
+                  <RoundInput
+                    selectedRound={previewRound}
+                    referenceRound={currentRoundFromCdn}
+                    onRoundChange={setPreviewRound}
+                    hasError={previewError !== null}
+                  />
                 </Stack>
-                <CodeBlock.AdapterProvider value={shikiAdapter}>
-                  <CodeBlock.Root code={formattedJson} language="json">
-                    <CodeBlock.Header>
-                      <HStack gap={2} flex={1}>
-                        <CodeBlock.Title>
-                          <Icon as={FaCode} color="nfc-green.solid" />
-                          {roundData.round || 'unknown'}.json
-                        </CodeBlock.Title>
-                        <Badge size="sm" colorPalette="nfc-blue">
-                          JSON
-                        </Badge>
-                      </HStack>
-                      <CodeBlock.CopyTrigger asChild>
-                        <IconButton variant="ghost" size="2xs">
-                          <CodeBlock.CopyIndicator />
-                        </IconButton>
-                      </CodeBlock.CopyTrigger>
-                    </CodeBlock.Header>
-                    <CodeBlock.Content maxH="calc(100vh - 300px)" overflowY="auto">
-                      <CodeBlock.Code>
-                        <CodeBlock.CodeText />
-                      </CodeBlock.Code>
-                    </CodeBlock.Content>
-                  </CodeBlock.Root>
-                </CodeBlock.AdapterProvider>
+                {previewLoading ? (
+                  <Text fontSize="sm" color="fg.muted">
+                    Loading round {previewRound}...
+                  </Text>
+                ) : previewError ? (
+                  <Text fontSize="sm" color="nfc-red.fg">
+                    {previewError}
+                  </Text>
+                ) : (
+                  <CodeBlock.AdapterProvider value={shikiAdapter}>
+                    <CodeBlock.Root code={formattedJson} language="json">
+                      <CodeBlock.Header>
+                        <HStack gap={2} flex={1}>
+                          <CodeBlock.Title>
+                            <Icon as={FaCode} color="nfc-green.solid" />
+                            {displayedRoundData.round || 'unknown'}.json
+                          </CodeBlock.Title>
+                          <Badge size="sm" colorPalette="nfc-blue">
+                            JSON
+                          </Badge>
+                        </HStack>
+                        <CodeBlock.CopyTrigger asChild>
+                          <IconButton variant="ghost" size="2xs">
+                            <CodeBlock.CopyIndicator />
+                          </IconButton>
+                        </CodeBlock.CopyTrigger>
+                      </CodeBlock.Header>
+                      <CodeBlock.Content maxH="calc(100vh - 300px)" overflowY="auto">
+                        <CodeBlock.Code>
+                          <CodeBlock.CodeText />
+                        </CodeBlock.Code>
+                      </CodeBlock.Content>
+                    </CodeBlock.Root>
+                  </CodeBlock.AdapterProvider>
+                )}
               </Stack>
             </Dialog.Body>
             <Dialog.Footer>

--- a/src/app/components/modals/RoundJsonModal.tsx
+++ b/src/app/components/modals/RoundJsonModal.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   Dialog,
   Portal,
@@ -236,41 +237,43 @@ export const RoundJsonModal: React.FC<RoundJsonModalProps> = ({ isOpen, onClose 
                     hasError={previewError !== null}
                   />
                 </Stack>
-                {previewLoading ? (
-                  <Text fontSize="sm" color="fg.muted">
-                    Loading round {previewRound}...
-                  </Text>
-                ) : previewError ? (
-                  <Text fontSize="sm" color="nfc-red.fg">
-                    {previewError}
-                  </Text>
-                ) : (
-                  <CodeBlock.AdapterProvider value={shikiAdapter}>
-                    <CodeBlock.Root code={formattedJson} language="json">
-                      <CodeBlock.Header>
-                        <HStack gap={2} flex={1}>
-                          <CodeBlock.Title>
-                            <Icon as={FaCode} color="nfc-green.solid" />
-                            {displayedRoundData.round || 'unknown'}.json
-                          </CodeBlock.Title>
-                          <Badge size="sm" colorPalette="nfc-blue">
-                            JSON
-                          </Badge>
-                        </HStack>
-                        <CodeBlock.CopyTrigger asChild>
-                          <IconButton variant="ghost" size="2xs">
-                            <CodeBlock.CopyIndicator />
-                          </IconButton>
-                        </CodeBlock.CopyTrigger>
-                      </CodeBlock.Header>
-                      <CodeBlock.Content maxH="calc(100vh - 300px)" overflowY="auto">
-                        <CodeBlock.Code>
-                          <CodeBlock.CodeText />
-                        </CodeBlock.Code>
-                      </CodeBlock.Content>
-                    </CodeBlock.Root>
-                  </CodeBlock.AdapterProvider>
-                )}
+                <Box minH="300px">
+                  {previewLoading ? (
+                    <Text fontSize="sm" color="fg.muted">
+                      Loading round {previewRound}...
+                    </Text>
+                  ) : previewError ? (
+                    <Text fontSize="sm" color="nfc-red.fg">
+                      {previewError}
+                    </Text>
+                  ) : (
+                    <CodeBlock.AdapterProvider value={shikiAdapter}>
+                      <CodeBlock.Root code={formattedJson} language="json">
+                        <CodeBlock.Header>
+                          <HStack gap={2} flex={1}>
+                            <CodeBlock.Title>
+                              <Icon as={FaCode} color="nfc-green.solid" />
+                              {displayedRoundData.round || 'unknown'}.json
+                            </CodeBlock.Title>
+                            <Badge size="sm" colorPalette="nfc-blue">
+                              JSON
+                            </Badge>
+                          </HStack>
+                          <CodeBlock.CopyTrigger asChild>
+                            <IconButton variant="ghost" size="2xs">
+                              <CodeBlock.CopyIndicator />
+                            </IconButton>
+                          </CodeBlock.CopyTrigger>
+                        </CodeBlock.Header>
+                        <CodeBlock.Content maxH="calc(100vh - 300px)" overflowY="auto">
+                          <CodeBlock.Code>
+                            <CodeBlock.CodeText />
+                          </CodeBlock.Code>
+                        </CodeBlock.Content>
+                      </CodeBlock.Root>
+                    </CodeBlock.AdapterProvider>
+                  )}
+                </Box>
               </Stack>
             </Dialog.Body>
             <Dialog.Footer>

--- a/src/app/components/modals/RoundJsonModal.tsx
+++ b/src/app/components/modals/RoundJsonModal.tsx
@@ -9,12 +9,15 @@ import {
   Badge,
   HStack,
   Icon,
+  Stack,
+  Text,
 } from '@chakra-ui/react';
 import * as React from 'react';
 import { FaCode } from 'react-icons/fa';
 import type { HighlighterGeneric } from 'shiki';
 
-import { useRoundStore } from '../../stores';
+import { useCurrentRound, useRoundStore } from '../../stores';
+import RoundInput from '../inputs/RoundInput';
 
 // Uses the fine-grained core API (rather than `createHighlighter` from the
 // `shiki` package) so the bundler only includes the json language and
@@ -126,6 +129,7 @@ const formatJsonWithDepth = (
 
 export const RoundJsonModal: React.FC<RoundJsonModalProps> = ({ isOpen, onClose }) => {
   const roundData = useRoundStore(state => state.roundData);
+  const currentRoundFromCdn = useCurrentRound();
 
   // Pretty-format the JSON with depth limit and special case for winners
   const formattedJson = formatJsonWithDepth(roundData, 2, ['winners']);
@@ -148,31 +152,42 @@ export const RoundJsonModal: React.FC<RoundJsonModalProps> = ({ isOpen, onClose 
               </Dialog.CloseTrigger>
             </Dialog.Header>
             <Dialog.Body>
-              <CodeBlock.AdapterProvider value={shikiAdapter}>
-                <CodeBlock.Root code={formattedJson} language="json">
-                  <CodeBlock.Header>
-                    <HStack gap={2} flex={1}>
-                      <CodeBlock.Title>
-                        <Icon as={FaCode} color="nfc-green.solid" />
-                        {roundData.round || 'unknown'}.json
-                      </CodeBlock.Title>
-                      <Badge size="sm" colorPalette="nfc-blue">
-                        JSON
-                      </Badge>
-                    </HStack>
-                    <CodeBlock.CopyTrigger asChild>
-                      <IconButton variant="ghost" size="2xs">
-                        <CodeBlock.CopyIndicator />
-                      </IconButton>
-                    </CodeBlock.CopyTrigger>
-                  </CodeBlock.Header>
-                  <CodeBlock.Content maxH="calc(100vh - 300px)" overflowY="auto">
-                    <CodeBlock.Code>
-                      <CodeBlock.CodeText />
-                    </CodeBlock.Code>
-                  </CodeBlock.Content>
-                </CodeBlock.Root>
-              </CodeBlock.AdapterProvider>
+              <Stack gap={3}>
+                <Stack gap={1} align="stretch">
+                  <Text fontSize="sm" fontWeight="medium">
+                    Change round
+                  </Text>
+                  <Text fontSize="xs" color="fg.muted">
+                    Current round on Neopets: {currentRoundFromCdn > 0 ? currentRoundFromCdn : '—'}
+                  </Text>
+                  <RoundInput />
+                </Stack>
+                <CodeBlock.AdapterProvider value={shikiAdapter}>
+                  <CodeBlock.Root code={formattedJson} language="json">
+                    <CodeBlock.Header>
+                      <HStack gap={2} flex={1}>
+                        <CodeBlock.Title>
+                          <Icon as={FaCode} color="nfc-green.solid" />
+                          {roundData.round || 'unknown'}.json
+                        </CodeBlock.Title>
+                        <Badge size="sm" colorPalette="nfc-blue">
+                          JSON
+                        </Badge>
+                      </HStack>
+                      <CodeBlock.CopyTrigger asChild>
+                        <IconButton variant="ghost" size="2xs">
+                          <CodeBlock.CopyIndicator />
+                        </IconButton>
+                      </CodeBlock.CopyTrigger>
+                    </CodeBlock.Header>
+                    <CodeBlock.Content maxH="calc(100vh - 300px)" overflowY="auto">
+                      <CodeBlock.Code>
+                        <CodeBlock.CodeText />
+                      </CodeBlock.Code>
+                    </CodeBlock.Content>
+                  </CodeBlock.Root>
+                </CodeBlock.AdapterProvider>
+              </Stack>
             </Dialog.Body>
             <Dialog.Footer>
               <Button variant="outline" onClick={onClose}>


### PR DESCRIPTION
Moves the "Change round" section (current-round info + `RoundInput`) out of the dev mode drawer and into the **View Round JSON** modal, just above the JSON CodeBlock.

- `RoundJsonModal` now renders the round selection in its body
- `DevModeDrawer` no longer renders it (and drops the now-unused imports)

Verified with `npm run typecheck`, `npm run lint`, and the e2e mobile spec (chromium + Mobile Chrome, 8/8 passing — includes the RoundJsonModal mobile overflow test).