### PR TITLE
Fix crash when viewing payout charts after selecting a bet

### DIFF
--- a/src/app/components/charts/PayoutCharts.tsx
+++ b/src/app/components/charts/PayoutCharts.tsx
@@ -4,6 +4,7 @@ import {
   LinearScale,
   PointElement,
   LineElement,
+  ScatterController,
   Tooltip,
   Legend,
   TooltipItem,
@@ -30,7 +31,15 @@ import PayoutScatter from './PayoutScatter';
 
 import { useColorMode } from '@/components/ui/color-mode';
 
-ChartJS.register(LinearScale, PointElement, LineElement, Tooltip, Legend, annotationPlugin);
+ChartJS.register(
+  LinearScale,
+  PointElement,
+  LineElement,
+  ScatterController,
+  Tooltip,
+  Legend,
+  annotationPlugin,
+);
 
 interface ChartPoint {
   x: number;


### PR DESCRIPTION
## Summary
- PayoutCharts renders a Chart.js scatter chart (via PayoutScatter) but never registered ScatterController, only LinearScale, PointElement, LineElement, Tooltip, Legend, and the annotation plugin.
- Without a registered controller for the "scatter" type, Chart.js cannot resolve the axis scale type and falls back to "category", which also isn't registered - throwing "category is not a registered scale" and crashing the page as soon as a bet is selected, since the payout charts only mount once a bet exists.
- Fix registers ScatterController alongside the other Chart.js pieces.