### PR TITLE
Add Bet Generation Max Bet setting (Capped/Uncapped)

### DIFF
--- a/src/app/components/TableSettings/BetGenerationMaxBetToggle.tsx
+++ b/src/app/components/TableSettings/BetGenerationMaxBetToggle.tsx
@@ -1,0 +1,65 @@
+import { HStack } from '@chakra-ui/react';
+import React, { useCallback, useMemo, useRef } from 'react';
+import { FaLock, FaLockOpen } from 'react-icons/fa6';
+import Cookies from 'universal-cookie';
+
+import { useBetGenerationMaxBetMode, useSetBetGenerationMaxBetMode } from '../../stores';
+import type { BetGenerationMaxBetMode } from '../../util';
+
+import { SegmentedSettingsRow } from './SegmentedSettingsRow';
+
+interface Option {
+  value: BetGenerationMaxBetMode;
+  label: React.ReactNode;
+}
+
+const BetGenerationMaxBetToggle = (): React.ReactElement => {
+  const mode = useBetGenerationMaxBetMode();
+  const setMode = useSetBetGenerationMaxBetMode();
+  const cookiesRef = useRef(new Cookies());
+
+  const options: Option[] = useMemo(
+    () => [
+      {
+        value: 'capped',
+        label: (
+          <HStack>
+            <FaLock />
+            Capped
+          </HStack>
+        ),
+      },
+      {
+        value: 'uncapped',
+        label: (
+          <HStack>
+            <FaLockOpen />
+            Uncapped
+          </HStack>
+        ),
+      },
+    ],
+    [],
+  );
+
+  const persistMode = useCallback(
+    (value: BetGenerationMaxBetMode): void => {
+      setMode(value);
+      cookiesRef.current.set('betGenerationMaxBetMode', value);
+    },
+    [setMode],
+  );
+
+  return (
+    <SegmentedSettingsRow
+      icon={FaLock}
+      label="Bet Generation Max Bet"
+      value={mode}
+      options={options}
+      onChange={persistMode}
+      testId="bet-generation-max-bet-segmented-control"
+    />
+  );
+};
+
+export default React.memo(BetGenerationMaxBetToggle);

--- a/src/app/components/views/EditBets.tsx
+++ b/src/app/components/views/EditBets.tsx
@@ -36,6 +36,7 @@ import {
 } from '../../stores';
 import DropDownTable from '../tables/DropDownTable';
 import NormalTable from '../tables/NormalTable';
+import BetGenerationMaxBetToggle from '../TableSettings/BetGenerationMaxBetToggle';
 import BetSetPosition from '../TableSettings/BetSetPosition';
 import ColorModeToggle from '../TableSettings/ColorModeToggle';
 import CopyDomainToggle from '../TableSettings/CopyDomainToggle';
@@ -346,6 +347,8 @@ export default React.memo(function EditBets(): React.ReactElement {
                     <TableModes />
 
                     <BetSetPosition />
+
+                    <BetGenerationMaxBetToggle />
 
                     <LogitModelToggle />
 

--- a/src/app/hooks/useBetManagement.ts
+++ b/src/app/hooks/useBetManagement.ts
@@ -1,7 +1,7 @@
 import { useMemo, useCallback } from 'react';
 
 import { Bet, BetAmount } from '../../types/bets';
-import { BET_AMOUNT_DEFAULT } from '../constants';
+import { BET_AMOUNT_DEFAULT, BET_AMOUNT_MIN } from '../constants';
 import { computePiratesBinary } from '../maths';
 import {
   useAllBetsForURLData,
@@ -15,6 +15,7 @@ import {
   useBetStore,
   useUsedProbabilities,
   useBetCount,
+  useBetGenerationMaxBetMode,
 } from '../stores';
 import {
   makeEmptyBets,
@@ -22,6 +23,7 @@ import {
   getMaxBet,
   anyBetsExist as anyBetsExistInSet,
   calculateBetMaps,
+  type BetGenerationMaxBetMode,
 } from '../util';
 import {
   wasmMakeMaxTerBets,
@@ -34,6 +36,28 @@ import {
 } from '../wasmEngine';
 
 import { useDuplicateBets } from './useDuplicateBets';
+
+// When the user's "Bet Generation Max Bet" setting is "uncapped", override every
+// generated bet's amount to a flat `maxBet`, ignoring the wasm engine's default
+// odds-based cap (min(maxBet, ceil(1_000_000 / odds))). "Capped" mode is a no-op
+// here since the wasm engine already returns odds-capped amounts.
+function applyBetGenerationMaxBetMode(
+  bets: Bet,
+  betAmounts: BetAmount,
+  maxBet: number,
+  mode: BetGenerationMaxBetMode,
+): BetAmount {
+  if (mode !== 'uncapped' || maxBet < BET_AMOUNT_MIN) {
+    return betAmounts;
+  }
+
+  const flattened: BetAmount = new Map();
+  for (const [betIndex, bet] of bets.entries()) {
+    const hasPirate = bet.some(pirate => pirate > 0);
+    flattened.set(betIndex, hasPirate ? maxBet : (betAmounts.get(betIndex) ?? BET_AMOUNT_DEFAULT));
+  }
+  return flattened;
+}
 
 export function useBetManagement(): {
   currentBetIndex: number;
@@ -68,6 +92,7 @@ export function useBetManagement(): {
 } {
   const currentSelectedRound = useSelectedRound();
   const usedProbabilities = useUsedProbabilities();
+  const betGenerationMaxBetMode = useBetGenerationMaxBetMode();
 
   // Use selective hooks for better performance
   const currentBetIndex = useCurrentBet();
@@ -267,8 +292,14 @@ export function useBetManagement(): {
   const generateMaxTERSet = useCallback((): void => {
     const maxBet = getMaxBet(currentSelectedRound);
     const { bets, betAmounts } = wasmMakeMaxTerBets(betCount);
-    addNewSet(`Max TER Set (${maxBet} NP)`, bets, betAmounts, true);
-  }, [addNewSet, betCount, currentSelectedRound]);
+    const finalAmounts = applyBetGenerationMaxBetMode(
+      bets,
+      betAmounts,
+      maxBet,
+      betGenerationMaxBetMode,
+    );
+    addNewSet(`Max TER Set (${maxBet} NP)`, bets, finalAmounts, true);
+  }, [addNewSet, betCount, currentSelectedRound, betGenerationMaxBetMode]);
 
   const generateTenbetSet = useCallback(
     (tenbetIndices: number[]): void => {
@@ -279,12 +310,18 @@ export function useBetManagement(): {
       // unsatisfiable selection), the wasm engine errors instead of hanging.
       try {
         const { bets, betAmounts } = wasmMakeTenbetBets(tenbetBinary, betCount);
-        addNewSet(`Custom Ten-bet Set (${maxBet} NP)`, bets, betAmounts, true);
+        const finalAmounts = applyBetGenerationMaxBetMode(
+          bets,
+          betAmounts,
+          maxBet,
+          betGenerationMaxBetMode,
+        );
+        addNewSet(`Custom Ten-bet Set (${maxBet} NP)`, bets, finalAmounts, true);
       } catch (error) {
         console.error('Could not generate ten-bet set:', error);
       }
     },
-    [betCount, currentSelectedRound, addNewSet],
+    [betCount, currentSelectedRound, addNewSet, betGenerationMaxBetMode],
   );
 
   // Helper function that returns bets and betAmounts
@@ -308,16 +345,28 @@ export function useBetManagement(): {
       if (bets.size === 0) {
         return;
       }
-      addNewSet(`Custom Gambit Set (${maxBet} NP)`, bets, betAmounts, true);
+      const finalAmounts = applyBetGenerationMaxBetMode(
+        bets,
+        betAmounts,
+        maxBet,
+        betGenerationMaxBetMode,
+      );
+      addNewSet(`Custom Gambit Set (${maxBet} NP)`, bets, finalAmounts, true);
     },
-    [createGambitWithPirates, currentSelectedRound, addNewSet],
+    [createGambitWithPirates, currentSelectedRound, addNewSet, betGenerationMaxBetMode],
   );
 
   const generateGambitSet = useCallback((): void => {
     const maxBet = getMaxBet(currentSelectedRound);
     const { bets, betAmounts } = wasmMakeBestGambitBets(betCount);
-    addNewSet(`Custom Gambit Set (${maxBet} NP)`, bets, betAmounts, true);
-  }, [addNewSet, betCount, currentSelectedRound]);
+    const finalAmounts = applyBetGenerationMaxBetMode(
+      bets,
+      betAmounts,
+      maxBet,
+      betGenerationMaxBetMode,
+    );
+    addNewSet(`Custom Gambit Set (${maxBet} NP)`, bets, finalAmounts, true);
+  }, [addNewSet, betCount, currentSelectedRound, betGenerationMaxBetMode]);
 
   const generateBustproofSet = useCallback((): void => {
     const result = wasmMakeBustproofBets(betCount);
@@ -325,13 +374,15 @@ export function useBetManagement(): {
       console.warn('Bustproof set not possible: no arena has a positive ratio this round.');
       return;
     }
-    addNewSet(
-      `Bustproof Set (round ${currentSelectedRound})`,
+    const maxBet = getMaxBet(currentSelectedRound);
+    const finalAmounts = applyBetGenerationMaxBetMode(
       result.bets,
       result.betAmounts,
-      true,
+      maxBet,
+      betGenerationMaxBetMode,
     );
-  }, [addNewSet, currentSelectedRound, betCount]);
+    addNewSet(`Bustproof Set (round ${currentSelectedRound})`, result.bets, finalAmounts, true);
+  }, [addNewSet, currentSelectedRound, betCount, betGenerationMaxBetMode]);
 
   const generateWinningGambitSet = useCallback((): void => {
     const maxBet = getMaxBet(currentSelectedRound);
@@ -340,14 +391,26 @@ export function useBetManagement(): {
       console.warn('No winners yet: cannot generate a winning gambit set.');
       return;
     }
-    addNewSet(`Custom Gambit Set (${maxBet} NP)`, result.bets, result.betAmounts, true);
-  }, [addNewSet, currentSelectedRound, betCount]);
+    const finalAmounts = applyBetGenerationMaxBetMode(
+      result.bets,
+      result.betAmounts,
+      maxBet,
+      betGenerationMaxBetMode,
+    );
+    addNewSet(`Custom Gambit Set (${maxBet} NP)`, result.bets, finalAmounts, true);
+  }, [addNewSet, currentSelectedRound, betCount, betGenerationMaxBetMode]);
 
   const generateRandomCrazySet = useCallback((): void => {
     const maxBet = getMaxBet(currentSelectedRound);
     const { bets, betAmounts } = wasmMakeCrazyBets(betCount);
-    addNewSet(`Crazy Set (${maxBet} NP)`, bets, betAmounts, true);
-  }, [addNewSet, betCount, currentSelectedRound]);
+    const finalAmounts = applyBetGenerationMaxBetMode(
+      bets,
+      betAmounts,
+      maxBet,
+      betGenerationMaxBetMode,
+    );
+    addNewSet(`Crazy Set (${maxBet} NP)`, bets, finalAmounts, true);
+  }, [addNewSet, betCount, currentSelectedRound, betGenerationMaxBetMode]);
 
   return {
     // Current data

--- a/src/app/hooks/useBetManagement.ts
+++ b/src/app/hooks/useBetManagement.ts
@@ -374,15 +374,16 @@ export function useBetManagement(): {
       console.warn('Bustproof set not possible: no arena has a positive ratio this round.');
       return;
     }
-    const maxBet = getMaxBet(currentSelectedRound);
-    const finalAmounts = applyBetGenerationMaxBetMode(
+    // Bustproof amounts are precisely calculated to guarantee no loss - the
+    // Bet Generation Max Bet setting (which would flatten amounts in "uncapped"
+    // mode) must not be applied here, or it would break that guarantee.
+    addNewSet(
+      `Bustproof Set (round ${currentSelectedRound})`,
       result.bets,
       result.betAmounts,
-      maxBet,
-      betGenerationMaxBetMode,
+      true,
     );
-    addNewSet(`Bustproof Set (round ${currentSelectedRound})`, result.bets, finalAmounts, true);
-  }, [addNewSet, currentSelectedRound, betCount, betGenerationMaxBetMode]);
+  }, [addNewSet, currentSelectedRound, betCount]);
 
   const generateWinningGambitSet = useCallback((): void => {
     const maxBet = getMaxBet(currentSelectedRound);

--- a/src/app/stores/index.ts
+++ b/src/app/stores/index.ts
@@ -8,7 +8,7 @@ import type {
 import type { Bet, BetAmount, OddsData, ProbabilitiesData } from '../../types/bets';
 import { BET_AMOUNT_DEFAULT } from '../constants';
 import { computePiratesBinary } from '../maths';
-import { anyBetsExist, type BetSetPosition } from '../util';
+import { anyBetsExist, type BetSetPosition, type BetGenerationMaxBetMode } from '../util';
 
 import { useBetStore } from './betStore';
 import { useRoundStore } from './roundStore';
@@ -160,6 +160,10 @@ export const useToggleUseLogitModel = (): (() => void) =>
 export const useMaxBet = (): number => useRoundStore(state => state.maxBet);
 export const useSetMaxBet = (): ((maxBet: number) => void) =>
   useRoundStore(state => state.setMaxBet);
+export const useBetGenerationMaxBetMode = (): BetGenerationMaxBetMode =>
+  useRoundStore(state => state.betGenerationMaxBetMode);
+export const useSetBetGenerationMaxBetMode = (): ((mode: BetGenerationMaxBetMode) => void) =>
+  useRoundStore(state => state.setBetGenerationMaxBetMode);
 export const useSetCustomOdds = (): ((odds: OddsData) => void) =>
   useRoundStore(state => state.setCustomOdds);
 export const useSetCustomProbs = (): ((probs: ProbabilitiesData) => void) =>

--- a/src/app/stores/roundStore.ts
+++ b/src/app/stores/roundStore.ts
@@ -8,6 +8,7 @@ import { defaultRoundData, BET_AMOUNT_MIN } from '../constants';
 import {
   calculateRoundData,
   getBetSetPosition,
+  getBetGenerationMaxBetMode,
   parseBetUrl,
   getTableMode,
   getUseWebDomain,
@@ -21,6 +22,7 @@ import {
   makeBetURL,
   getMaxBet,
   type BetSetPosition,
+  type BetGenerationMaxBetMode,
 } from '../util';
 import {
   rebuildEngine,
@@ -102,6 +104,7 @@ interface RoundStore {
   oddsTimeline: boolean;
   useLogitModel: boolean;
   maxBet: number;
+  betGenerationMaxBetMode: BetGenerationMaxBetMode;
 
   // Calculations
   calculations: RoundCalculationResult;
@@ -128,6 +131,7 @@ interface RoundStore {
   toggleCustomOddsMode: () => void;
   toggleUseLogitModel: () => void;
   setMaxBet: (maxBet: number) => void;
+  setBetGenerationMaxBetMode: (mode: BetGenerationMaxBetMode) => void;
 
   // Calculations
   recalculate: () => void;
@@ -166,6 +170,7 @@ export const useRoundStore = create<RoundStore>()(
     oddsTimeline: getOddsTimelineMode(),
     useLogitModel: getUseLogitModel(),
     maxBet: getMaxBet(0),
+    betGenerationMaxBetMode: getBetGenerationMaxBetMode(),
 
     // Calculations
     calculations: emptyCalculations,
@@ -319,6 +324,9 @@ export const useRoundStore = create<RoundStore>()(
         }
       }
     },
+
+    setBetGenerationMaxBetMode: (mode: BetGenerationMaxBetMode): void =>
+      set({ betGenerationMaxBetMode: mode }),
 
     toggleBigBrain: (): void => set(state => ({ bigBrain: !state.bigBrain })),
     toggleFaDetails: (): void => set(state => ({ faDetails: !state.faDetails })),

--- a/src/app/util.ts
+++ b/src/app/util.ts
@@ -229,6 +229,13 @@ export function getBetSetPosition(): BetSetPosition {
   return getCookieOption('betSetPosition', BET_SET_POSITIONS, 'below');
 }
 
+export const BET_GENERATION_MAX_BET_MODES = ['capped', 'uncapped'] as const;
+export type BetGenerationMaxBetMode = (typeof BET_GENERATION_MAX_BET_MODES)[number];
+
+export function getBetGenerationMaxBetMode(): BetGenerationMaxBetMode {
+  return getCookieOption('betGenerationMaxBetMode', BET_GENERATION_MAX_BET_MODES, 'capped');
+}
+
 function getCookieOption<const T extends readonly string[]>(
   key: string,
   validOptions: T,


### PR DESCRIPTION
## Summary
- Adds a "Bet Generation Max Bet" setting (Capped/Uncapped segmented control, defaults to Capped) alongside the other table settings.
- Wires the setting into all bet-generation flows (Max TER, Gambit, Bustproof, Winning Gambit, Crazy, Ten-bet, and the modal-driven custom Gambit/Ten-bet builders): Capped keeps the existing odds-based amount cap, Uncapped flattens generated amounts to the raw max bet, matching the semantics of the existing manual Capped/Uncapped buttons used when editing bet amounts.
- Default (Capped) matches current behavior, so nothing changes unless a user opts into Uncapped.