### PR TITLE
Bring smooth number/color transitions to the arena bet table

### DIFF
--- a/src/app/__tests__/ArenaTableBody.arenaRatio.test.tsx
+++ b/src/app/__tests__/ArenaTableBody.arenaRatio.test.tsx
@@ -1,0 +1,99 @@
+import fs from 'fs';
+import path from 'path';
+
+import { Table } from '@chakra-ui/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { render, screen } from '../../test/utils';
+import type { RoundData } from '../../types';
+import ArenaTableBody from '../components/tables/ArenaTableBody';
+import { useBetStore } from '../stores/betStore';
+import { useRoundStore } from '../stores/roundStore';
+
+vi.mock('universal-cookie', () => ({
+  default: vi.fn().mockImplementation(function () {
+    return {
+      get: vi.fn().mockReturnValue(undefined),
+      set: vi.fn(),
+    };
+  }),
+}));
+
+/**
+ * Regression test: the arena ratio header cell rendered
+ * `<AnimatedNumber value={currentArenaRatio as number} />` even while
+ * currentArenaRatio was genuinely undefined (before the round store's
+ * first calculation completes) - the `as number` cast just lied to the
+ * type checker. displayAsPercent(undefined, 1) is itself "NaN%", and
+ * useTween's lerp interpolating from `undefined` is NaN for the whole
+ * transition too, so this showed up both as a momentary flash and (worse)
+ * a statically wrong value if calculations were slow to finish.
+ */
+describe('ArenaTableBody arena ratio', () => {
+  const fixturesPath = path.resolve(__dirname, 'fixtures/rounds.jsonl');
+  const roundData: RoundData = JSON.parse(
+    fs.readFileSync(fixturesPath, 'utf8').trim().split('\n')[0]!,
+  );
+
+  const noop = vi.fn();
+
+  beforeEach(() => {
+    useBetStore.setState({
+      currentBet: 0,
+      allBets: new Map([[0, new Map()]]),
+      allBetAmounts: new Map([[0, new Map()]]),
+      allNames: new Map([[0, 'Test Set']]),
+    });
+  });
+
+  function renderArena(): void {
+    render(
+      <Table.Root>
+        <ArenaTableBody
+          arenaId={0}
+          handleTimelineClick={noop}
+          handleArenaTimelineClick={noop}
+          handleBetLineChange={noop}
+        />
+      </Table.Root>,
+    );
+  }
+
+  it('never renders NaN% before the round store has calculated arena ratios', () => {
+    useRoundStore.setState({
+      roundData,
+      currentSelectedRound: roundData.round,
+      currentRound: roundData.round,
+      bigBrain: true,
+    });
+    // Deliberately don't call recalculate() - simulates the window right
+    // after roundData loads but before calculations (and thus arenaRatios)
+    // have run, which is exactly when the bug showed up.
+    useRoundStore.setState(state => ({
+      calculations: { ...state.calculations, calculated: false, arenaRatios: [] },
+    }));
+
+    renderArena();
+
+    const headerRow = screen.getAllByRole('row')[0]!;
+    expect(headerRow.textContent).not.toContain('NaN');
+  });
+
+  it('shows the real arena ratio once calculations have run', () => {
+    useRoundStore.setState({
+      roundData,
+      currentSelectedRound: roundData.round,
+      currentRound: roundData.round,
+      bigBrain: true,
+    });
+    useRoundStore.getState().recalculate();
+
+    renderArena();
+
+    const headerRow = screen.getAllByRole('row')[0]!;
+    const arenaRatio = useRoundStore.getState().calculations.arenaRatios[0];
+    expect(arenaRatio).toBeDefined();
+    expect(headerRow.textContent).toContain(`${(arenaRatio! * 100).toFixed(1)}%`);
+    expect(headerRow.textContent).not.toContain('NaN');
+  });
+});

--- a/src/app/components/tables/ArenaTableBody.tsx
+++ b/src/app/components/tables/ArenaTableBody.tsx
@@ -59,6 +59,7 @@ import OddsTimeline from '../timeline/OddsTimeline';
 import AnimatedNumber from '../ui/AnimatedNumber';
 import FaDetailsElement from '../ui/FaDetailsElement';
 import TextTooltip from '../ui/TextTooltip';
+import { fillColorStyle, useBackgroundColorTween } from '../ui/useBackgroundColorTween';
 
 import Td from './Td';
 
@@ -91,12 +92,15 @@ const PirateFA = React.memo(
       indicator = `-${neg}`;
     }
 
+    const bg = useBackgroundColorTween(color);
+
     return (
       <FaDetailsElement
         key={`fa-${foodId}-pirate-${pirateId}`}
         as={Td}
         textAlign="end"
-        {...(color && { layerStyle: 'fill.subtle', colorPalette: color })}
+        className="nfc-color-tween"
+        style={fillColorStyle(bg, color)}
         whiteSpace="nowrap"
       >
         <Text as={'b'}>{indicator}</Text>
@@ -110,7 +114,7 @@ PirateFA.displayName = 'PirateFA';
 // A sticky Td component for the first column
 const StickyTd = React.memo(
   (props: React.ComponentProps<typeof Table.Cell> & { cursor?: string }): React.ReactElement => {
-    const { children, onClick, cursor = undefined, ...rest } = props;
+    const { children, onClick, cursor = undefined, style, ...rest } = props;
 
     // Filter out undefined values to satisfy exactOptionalPropertyTypes
     const filteredRest = Object.fromEntries(
@@ -118,14 +122,17 @@ const StickyTd = React.memo(
     );
 
     const tdProps: React.ComponentProps<typeof Table.Cell> = {
-      style: {
-        position: 'sticky',
-        left: '0',
-      } as React.CSSProperties,
       zIndex: 1,
       ...(cursor && { cursor }),
       onClick,
       ...filteredRest,
+      // Merged (not spread before filteredRest) so a caller-supplied style
+      // adds to the sticky positioning instead of replacing it.
+      style: {
+        position: 'sticky',
+        left: '0',
+        ...style,
+      } as React.CSSProperties,
     };
 
     return <Td {...tdProps}>{children}</Td>;
@@ -266,7 +273,12 @@ const ArenaRatioDisplay = React.memo(
     return (
       <Skeleton loading={currentArenaRatio === undefined}>
         <TextTooltip
-          text={displayAsPercent(currentArenaRatio as number, 1)}
+          text={
+            <AnimatedNumber
+              value={currentArenaRatio as number}
+              format={v => displayAsPercent(v, 1)}
+            />
+          }
           content={`${(currentArenaRatio as number) * 100}%`}
         />
       </Skeleton>
@@ -403,6 +415,12 @@ const PirateRow = React.memo(
     const winningBetBinary = useWinningBetBinary();
     const pirateBin = computePirateBinary(arenaId, pirateIndex + 1);
     const pirateWon = (winningBetBinary & pirateBin) === pirateBin;
+    // Hooks must run unconditionally before the !pirateId early return below,
+    // so these are computed here rather than inline in the JSX/memos that use
+    // them. winColorKey/winBg are reused everywhere a cell just wants "green
+    // when this pirate won, otherwise no color".
+    const winColorKey = pirateWon ? 'nfc-green' : undefined;
+    const winBg = useBackgroundColorTween(winColorKey);
     const betCount = useBetCount();
     const prob = useStableUsedProbability(arenaId, pirateIndex + 1);
     const logitProb = useStableLogitProbability(arenaId, pirateIndex + 1);
@@ -413,6 +431,10 @@ const PirateRow = React.memo(
     const customOddsMode = useCustomOddsMode();
     const customOddsValue = useCustomOddsValue(arenaId, pirateIndex + 1);
     const getPirateBgColor = useGetPirateBgColor();
+    // The pirate-name cell's "off" state is a real odds-tier color, not
+    // transparent, so it needs its own tween separate from winBg.
+    const nameCellColorKey = pirateWon ? 'nfc-green' : getPirateBgColor(openingOdds!);
+    const nameCellBg = useBackgroundColorTween(nameCellColorKey);
     const faDetails = useFaDetails();
     // Payout should reflect Custom Odds when active, matching how the bet-level
     // Odds/Payoff columns already resolve odds (see getOdds() in util.ts) -
@@ -429,6 +451,7 @@ const PirateRow = React.memo(
       }
       return undefined;
     }, [payout, pirateWon]);
+    const payoutBg = useBackgroundColorTween(payoutBackground);
 
     const handleTimelineClickLocal = useCallback(() => {
       handleTimelineClick(arenaId, pirateIndex);
@@ -543,14 +566,11 @@ const PirateRow = React.memo(
       }
 
       return (
-        <Td
-          textAlign="end"
-          {...(pirateWon && { layerStyle: 'fill.subtle', colorPalette: 'nfc-green' })}
-        >
-          {displayAsPercent(logitProb, 1)}
+        <Td textAlign="end" className="nfc-color-tween" style={fillColorStyle(winBg, winColorKey)}>
+          <AnimatedNumber value={logitProb} format={v => displayAsPercent(v, 1)} />
         </Td>
       );
-    }, [logitProb, useLogitModel, bigBrain, pirateWon]);
+    }, [logitProb, useLogitModel, bigBrain, winBg, winColorKey]);
 
     const faElement = useMemo(() => {
       if (!bigBrain) {
@@ -558,14 +578,11 @@ const PirateRow = React.memo(
       }
 
       return (
-        <Td
-          textAlign="end"
-          {...(pirateWon && { layerStyle: 'fill.subtle', colorPalette: 'nfc-green' })}
-        >
-          {pirateFA}
+        <Td textAlign="end" className="nfc-color-tween" style={fillColorStyle(winBg, winColorKey)}>
+          <AnimatedNumber value={pirateFA} precision={0} />
         </Td>
       );
-    }, [pirateFA, bigBrain, pirateWon]);
+    }, [pirateFA, bigBrain, winBg, winColorKey]);
 
     const legacyProbElements = useMemo(() => {
       if (!bigBrain) {
@@ -580,25 +597,28 @@ const PirateRow = React.memo(
         <>
           <Td
             textAlign="end"
-            {...(pirateWon && { layerStyle: 'fill.subtle', colorPalette: 'nfc-green' })}
+            className="nfc-color-tween"
+            style={fillColorStyle(winBg, winColorKey)}
           >
-            {displayAsPercent(legacyProbMin, 1)}
+            <AnimatedNumber value={legacyProbMin} format={v => displayAsPercent(v, 1)} />
           </Td>
           <Td
             textAlign="end"
-            {...(pirateWon && { layerStyle: 'fill.subtle', colorPalette: 'nfc-green' })}
+            className="nfc-color-tween"
+            style={fillColorStyle(winBg, winColorKey)}
           >
-            {displayAsPercent(legacyProbMax, 1)}
+            <AnimatedNumber value={legacyProbMax} format={v => displayAsPercent(v, 1)} />
           </Td>
           <Td
             textAlign="end"
-            {...(pirateWon && { layerStyle: 'fill.subtle', colorPalette: 'nfc-green' })}
+            className="nfc-color-tween"
+            style={fillColorStyle(winBg, winColorKey)}
           >
-            {displayAsPercent(legacyProbStd, 1)}
+            <AnimatedNumber value={legacyProbStd} format={v => displayAsPercent(v, 1)} />
           </Td>
         </>
       );
-    }, [legacyProbMin, legacyProbMax, legacyProbStd, useLogitModel, bigBrain, pirateWon]);
+    }, [legacyProbMin, legacyProbMax, legacyProbStd, useLogitModel, bigBrain, winBg, winColorKey]);
 
     const faDetailsElement = useMemo(() => {
       if (!foods) {
@@ -684,12 +704,13 @@ const PirateRow = React.memo(
       return (
         <Td
           textAlign="end"
-          {...(payoutBackground && { layerStyle: 'fill.subtle', colorPalette: payoutBackground })}
+          className="nfc-color-tween"
+          style={fillColorStyle(payoutBg, payoutBackground)}
         >
           <AnimatedNumber value={payout} format={v => displayAsPercent(v, 1)} />
         </Td>
       );
-    }, [payout, payoutBackground, bigBrain]);
+    }, [payout, payoutBackground, payoutBg, bigBrain]);
 
     // Odds comparison logic
     const oddsIncreased = currentOdds! > openingOdds!;
@@ -712,11 +733,12 @@ const PirateRow = React.memo(
     return (
       <Table.Row
         key={`pirate-${pirateId}-${arenaId}`}
-        backgroundColor={pirateWon ? 'nfc-green.subtle' : 'transparent'}
+        className="nfc-color-tween"
+        style={fillColorStyle(winBg, winColorKey)}
       >
         <StickyTd
-          layerStyle={pirateWon ? 'fill.subtle' : 'fill.muted'}
-          colorPalette={pirateWon ? 'nfc-green' : getPirateBgColor(openingOdds!)}
+          className="nfc-color-tween"
+          style={fillColorStyle(nameCellBg, nameCellColorKey)}
           onClick={handleTimelineClickLocal}
           cursor="pointer"
           title={`Click to view odds timeline for ${fullPirateName}`}
@@ -728,16 +750,15 @@ const PirateRow = React.memo(
         {payoutElement}
         {faElement}
         {faDetailsElement}
-        <Td
-          textAlign="end"
-          {...(pirateWon && { layerStyle: 'fill.subtle', colorPalette: 'nfc-green' })}
-        >
-          {openingOdds}:1
+        <Td textAlign="end" className="nfc-color-tween" style={fillColorStyle(winBg, winColorKey)}>
+          <AnimatedNumber value={openingOdds!} precision={0} />
+          :1
         </Td>
         <Td
           textAlign="end"
           whiteSpace="nowrap"
-          {...(pirateWon && { layerStyle: 'fill.subtle', colorPalette: 'nfc-green' })}
+          className="nfc-color-tween"
+          style={fillColorStyle(winBg, winColorKey)}
         >
           <Box display="flex" alignItems="center" justifyContent="flex-end">
             {oddsChanged && (

--- a/src/app/components/tables/ArenaTableBody.tsx
+++ b/src/app/components/tables/ArenaTableBody.tsx
@@ -571,10 +571,14 @@ const PirateRow = React.memo(
 
       return (
         <Td textAlign="end" className="nfc-color-tween" style={fillColorStyle(winBg, winColorKey)}>
-          <AnimatedNumber value={logitProb} format={v => displayAsPercent(v, 1)} />
+          <AnimatedNumber
+            value={logitProb}
+            format={v => displayAsPercent(v, 1)}
+            persistKey={`pirate-${arenaId}-${pirateIndex}-logitProb`}
+          />
         </Td>
       );
-    }, [logitProb, useLogitModel, bigBrain, winBg, winColorKey]);
+    }, [logitProb, useLogitModel, bigBrain, winBg, winColorKey, arenaId, pirateIndex]);
 
     const faElement = useMemo(() => {
       if (!bigBrain) {
@@ -583,10 +587,14 @@ const PirateRow = React.memo(
 
       return (
         <Td textAlign="end" className="nfc-color-tween" style={fillColorStyle(winBg, winColorKey)}>
-          <AnimatedNumber value={pirateFA} precision={0} />
+          <AnimatedNumber
+            value={pirateFA}
+            precision={0}
+            persistKey={`pirate-${arenaId}-${pirateIndex}-fa`}
+          />
         </Td>
       );
-    }, [pirateFA, bigBrain, winBg, winColorKey]);
+    }, [pirateFA, bigBrain, winBg, winColorKey, arenaId, pirateIndex]);
 
     const legacyProbElements = useMemo(() => {
       if (!bigBrain) {
@@ -604,25 +612,47 @@ const PirateRow = React.memo(
             className="nfc-color-tween"
             style={fillColorStyle(winBg, winColorKey)}
           >
-            <AnimatedNumber value={legacyProbMin} format={v => displayAsPercent(v, 1)} />
+            <AnimatedNumber
+              value={legacyProbMin}
+              format={v => displayAsPercent(v, 1)}
+              persistKey={`pirate-${arenaId}-${pirateIndex}-legacyProbMin`}
+            />
           </Td>
           <Td
             textAlign="end"
             className="nfc-color-tween"
             style={fillColorStyle(winBg, winColorKey)}
           >
-            <AnimatedNumber value={legacyProbMax} format={v => displayAsPercent(v, 1)} />
+            <AnimatedNumber
+              value={legacyProbMax}
+              format={v => displayAsPercent(v, 1)}
+              persistKey={`pirate-${arenaId}-${pirateIndex}-legacyProbMax`}
+            />
           </Td>
           <Td
             textAlign="end"
             className="nfc-color-tween"
             style={fillColorStyle(winBg, winColorKey)}
           >
-            <AnimatedNumber value={legacyProbStd} format={v => displayAsPercent(v, 1)} />
+            <AnimatedNumber
+              value={legacyProbStd}
+              format={v => displayAsPercent(v, 1)}
+              persistKey={`pirate-${arenaId}-${pirateIndex}-legacyProbStd`}
+            />
           </Td>
         </>
       );
-    }, [legacyProbMin, legacyProbMax, legacyProbStd, useLogitModel, bigBrain, winBg, winColorKey]);
+    }, [
+      legacyProbMin,
+      legacyProbMax,
+      legacyProbStd,
+      useLogitModel,
+      bigBrain,
+      winBg,
+      winColorKey,
+      arenaId,
+      pirateIndex,
+    ]);
 
     const faDetailsElement = useMemo(() => {
       if (!foods) {
@@ -711,10 +741,14 @@ const PirateRow = React.memo(
           className="nfc-color-tween"
           style={fillColorStyle(payoutBg, payoutBackground)}
         >
-          <AnimatedNumber value={payout} format={v => displayAsPercent(v, 1)} />
+          <AnimatedNumber
+            value={payout}
+            format={v => displayAsPercent(v, 1)}
+            persistKey={`pirate-${arenaId}-${pirateIndex}-payout`}
+          />
         </Td>
       );
-    }, [payout, payoutBackground, payoutBg, bigBrain]);
+    }, [payout, payoutBackground, payoutBg, bigBrain, arenaId, pirateIndex]);
 
     // Odds comparison logic
     const oddsIncreased = currentOdds! > openingOdds!;
@@ -755,7 +789,11 @@ const PirateRow = React.memo(
         {faElement}
         {faDetailsElement}
         <Td textAlign="end" className="nfc-color-tween" style={fillColorStyle(winBg, winColorKey)}>
-          <AnimatedNumber value={openingOdds!} precision={0} />
+          <AnimatedNumber
+            value={openingOdds!}
+            precision={0}
+            persistKey={`pirate-${arenaId}-${pirateIndex}-openingOdds`}
+          />
           :1
         </Td>
         <Td
@@ -776,7 +814,11 @@ const PirateRow = React.memo(
               </Box>
             )}
             <Text fontWeight={oddsChanged ? 'bold' : 'normal'}>
-              <AnimatedNumber value={currentOdds!} precision={0} />
+              <AnimatedNumber
+                value={currentOdds!}
+                precision={0}
+                persistKey={`pirate-${arenaId}-${pirateIndex}-currentOdds`}
+              />
               :1
             </Text>
           </Box>

--- a/src/app/components/tables/ArenaTableBody.tsx
+++ b/src/app/components/tables/ArenaTableBody.tsx
@@ -932,10 +932,15 @@ const ArenaTableBody = React.memo(
       const pirateIdsForRows =
         piratesForArena && piratesForArena.length > 0 ? piratesForArena : makeEmpty(4);
 
-      return pirateIdsForRows.map((pirateId, pirateIndex) => (
+      return pirateIdsForRows.map((_pirateId, pirateIndex) => (
         <PirateRow
+          // Keyed by slot (arena + position), not pirateId: a different
+          // pirate occupies the same slot on a different round, and keying
+          // by pirateId would remount the row on every round switch,
+          // resetting the color tween's in-flight state instead of letting
+          // it animate from the previous color.
           // eslint-disable-next-line react/no-array-index-key
-          key={`pirate-${arenaId}-${pirateIndex}-${pirateId}`}
+          key={`pirate-${arenaId}-${pirateIndex}`}
           pirateIndex={pirateIndex}
           arenaId={arenaId}
           handleTimelineClick={handleTimelineClick}

--- a/src/app/components/tables/ArenaTableBody.tsx
+++ b/src/app/components/tables/ArenaTableBody.tsx
@@ -272,15 +272,19 @@ const ArenaRatioDisplay = React.memo(
 
     return (
       <Skeleton loading={currentArenaRatio === undefined}>
-        <TextTooltip
-          text={
-            <AnimatedNumber
-              value={currentArenaRatio as number}
-              format={v => displayAsPercent(v, 1)}
-            />
-          }
-          content={`${(currentArenaRatio as number) * 100}%`}
-        />
+        {currentArenaRatio !== undefined ? (
+          <TextTooltip
+            text={<AnimatedNumber value={currentArenaRatio} format={v => displayAsPercent(v, 1)} />}
+            content={`${currentArenaRatio * 100}%`}
+          />
+        ) : (
+          // Placeholder so the Skeleton has something to size itself
+          // against before currentArenaRatio is ready - never render
+          // AnimatedNumber with an undefined value, since useTween's lerp
+          // (from + (to - from) * t) produces NaN when interpolating from
+          // undefined.
+          <Text>0.0%</Text>
+        )}
       </Skeleton>
     );
   },

--- a/src/app/components/tables/DropDownTable.tsx
+++ b/src/app/components/tables/DropDownTable.tsx
@@ -23,6 +23,7 @@ import { computeDuplicateBetGroupColors } from '../../utils/duplicateBetColors';
 import ClearBetsButton from '../bets/ClearBetsButton';
 import PirateSelect from '../bets/PirateSelect';
 import AnimatedNumber from '../ui/AnimatedNumber';
+import { fillColorStyle, useBackgroundColorTween } from '../ui/useBackgroundColorTween';
 
 import Td from './Td';
 
@@ -121,25 +122,36 @@ const PirateInfoRow = React.memo(
     const opening = openingOdds[pirateIndex + 1] as number;
     const current = currentOdds[pirateIndex + 1] as number;
 
+    const winColorKey = didPirateWin ? 'nfc-green' : undefined;
+    const winBg = useBackgroundColorTween(winColorKey);
+    // The pirate-name cell's "off" state is a real odds-tier color, not
+    // transparent, so it needs its own tween separate from winBg.
+    const nameCellColorKey = didPirateWin ? 'nfc-green' : getPirateBgColor(opening);
+    const nameCellBg = useBackgroundColorTween(nameCellColorKey);
+
     const fullPirateName = FULL_PIRATE_NAMES.get(pirateId) as string;
     const pirateName = PIRATE_NAMES.get(pirateId) as string;
 
     return (
       <Table.Row
         key={`pirate-${pirateId}-${arenaId}-${pirateIndex}`}
-        {...(didPirateWin && { layerStyle: 'fill.subtle', colorPalette: 'nfc-green' })}
+        className="nfc-color-tween"
+        style={fillColorStyle(winBg, winColorKey)}
       >
         <Td
           whiteSpace="nowrap"
           onClick={onClick}
           cursor="pointer"
           title={`Click to view odds timeline for ${fullPirateName}`}
-          layerStyle={didPirateWin ? 'fill.subtle' : 'fill.muted'}
-          colorPalette={didPirateWin ? 'nfc-green' : getPirateBgColor(opening)}
+          className="nfc-color-tween"
+          style={fillColorStyle(nameCellBg, nameCellColorKey)}
         >
           {pirateName}
         </Td>
-        <Td style={{ textAlign: 'end' }}>{opening}:1</Td>
+        <Td style={{ textAlign: 'end' }}>
+          <AnimatedNumber value={opening} precision={0} />
+          :1
+        </Td>
         <Td style={{ textAlign: 'end' }}>
           <Text fontWeight={current === opening ? 'normal' : 'bold'}>
             <AnimatedNumber value={current} precision={0} />
@@ -162,9 +174,6 @@ const TableHeaderCell = React.memo(
   ({ arenaId, onArenaClick }: { arenaId: number; onArenaClick: (arenaId: number) => void }) => {
     const arenaRatios = useArenaRatios();
     const bigBrain = useBigBrain();
-    const arenaRatioString = bigBrain
-      ? `(${displayAsPercent(arenaRatios[arenaId] as number, 1)})`
-      : '';
 
     return (
       <Table.ColumnHeader
@@ -174,7 +183,17 @@ const TableHeaderCell = React.memo(
         title={`Click to view odds timeline for ${ARENA_NAMES[arenaId]}`}
         _hover={{ bg: 'bg.muted' }}
       >
-        {ARENA_NAMES[arenaId]} {arenaRatioString}
+        {ARENA_NAMES[arenaId]}{' '}
+        {bigBrain && (
+          <>
+            (
+            <AnimatedNumber
+              value={arenaRatios[arenaId] as number}
+              format={v => displayAsPercent(v, 1)}
+            />
+            )
+          </>
+        )}
       </Table.ColumnHeader>
     );
   },

--- a/src/app/components/tables/DropDownTable.tsx
+++ b/src/app/components/tables/DropDownTable.tsx
@@ -238,8 +238,13 @@ const ArenaCell = React.memo(
 
           return (
             <PirateInfoRow
+              // Keyed by slot (arena + position), not pirateId: a different
+              // pirate occupies the same slot on a different round, and
+              // keying by pirateId would remount the row on every round
+              // switch, resetting the color tween's in-flight state instead
+              // of letting it animate from the previous color.
               // eslint-disable-next-line react/no-array-index-key
-              key={`pirate-${pirateId}-${arenaId}-${pirateIndex}`}
+              key={`pirate-${arenaId}-${pirateIndex}`}
               pirateId={pirateId}
               pirateIndex={pirateIndex}
               arenaId={arenaId}

--- a/src/app/components/tables/DropDownTable.tsx
+++ b/src/app/components/tables/DropDownTable.tsx
@@ -149,12 +149,20 @@ const PirateInfoRow = React.memo(
           {pirateName}
         </Td>
         <Td style={{ textAlign: 'end' }}>
-          <AnimatedNumber value={opening} precision={0} />
+          <AnimatedNumber
+            value={opening}
+            precision={0}
+            persistKey={`pirate-${arenaId}-${pirateIndex}-openingOdds`}
+          />
           :1
         </Td>
         <Td style={{ textAlign: 'end' }}>
           <Text fontWeight={current === opening ? 'normal' : 'bold'}>
-            <AnimatedNumber value={current} precision={0} />
+            <AnimatedNumber
+              value={current}
+              precision={0}
+              persistKey={`pirate-${arenaId}-${pirateIndex}-currentOdds`}
+            />
             :1
           </Text>
         </Td>

--- a/src/app/components/tables/DropDownTable.tsx
+++ b/src/app/components/tables/DropDownTable.tsx
@@ -184,14 +184,9 @@ const TableHeaderCell = React.memo(
         _hover={{ bg: 'bg.muted' }}
       >
         {ARENA_NAMES[arenaId]}{' '}
-        {bigBrain && (
+        {bigBrain && arenaRatios[arenaId] !== undefined && (
           <>
-            (
-            <AnimatedNumber
-              value={arenaRatios[arenaId] as number}
-              format={v => displayAsPercent(v, 1)}
-            />
-            )
+            (<AnimatedNumber value={arenaRatios[arenaId]} format={v => displayAsPercent(v, 1)} />)
           </>
         )}
       </Table.ColumnHeader>

--- a/src/app/components/tables/PayoutTable.tsx
+++ b/src/app/components/tables/PayoutTable.tsx
@@ -1,5 +1,4 @@
 import { Box, HStack, IconButton, Skeleton, Spacer, Table, Text } from '@chakra-ui/react';
-import { oklab, rgb, formatRgb, type Oklab } from 'culori';
 import React, { useCallback, useMemo } from 'react';
 import { FaArrowDown, FaArrowUp } from 'react-icons/fa6';
 
@@ -42,7 +41,7 @@ import BetAmountInput from '../bets/BetAmountInput';
 import PlaceThisBetButton from '../bets/PlaceThisBetButton';
 import AnimatedNumber from '../ui/AnimatedNumber';
 import TextTooltip from '../ui/TextTooltip';
-import { useTween } from '../ui/useTween';
+import { fillColorStyle, useBackgroundColorTween } from '../ui/useBackgroundColorTween';
 
 import Td from './Td';
 
@@ -72,53 +71,6 @@ const stickySubmitHeaderProps = {
   ...stickySubmitColumnProps,
   zIndex: 2,
 } as const;
-
-const resolveSubtleColor = (colorKey: string | undefined): Oklab => {
-  if (!colorKey || typeof window === 'undefined') {
-    return { mode: 'oklab', l: 0, a: 0, b: 0, alpha: 0 };
-  }
-  const raw = window
-    .getComputedStyle(document.documentElement)
-    .getPropertyValue(`--chakra-colors-${colorKey}-subtle`);
-  return oklab(raw) ?? { mode: 'oklab', l: 0, a: 0, b: 0, alpha: 0 };
-};
-
-const lerpOklab = (from: Oklab, to: Oklab, t: number): Oklab => ({
-  mode: 'oklab',
-  l: (from.l ?? 0) + ((to.l ?? 0) - (from.l ?? 0)) * t,
-  a: (from.a ?? 0) + ((to.a ?? 0) - (from.a ?? 0)) * t,
-  b: (from.b ?? 0) + ((to.b ?? 0) - (from.b ?? 0)) * t,
-  alpha: (from.alpha ?? 1) + ((to.alpha ?? 1) - (from.alpha ?? 1)) * t,
-});
-
-const oklabEqual = (x: Oklab, y: Oklab): boolean =>
-  x.l === y.l && x.a === y.a && x.b === y.b && (x.alpha ?? 1) === (y.alpha ?? 1);
-
-// Animates a cell's background color frame-by-frame in JS instead of via a
-// CSS transition, which proved unreliable here: cells could get stuck
-// showing a stale color after a round switch even though the DOM's computed
-// style was already correct (a browser repaint bug), and workarounds that
-// forced a repaint afterward either didn't fix it consistently or
-// introduced their own visible glitches. Reuses the same tween mechanics
-// AnimatedNumber uses for numbers.
-//
-// Interpolates in OKLab (a perceptually-uniform color space) rather than
-// raw sRGB - a plain RGB lerp between e.g. nfc-green and nfc-red (a direct
-// win-to-loss flip on the same bet slot) passes through a muddy tan/khaki
-// midpoint, since red and green are near-opposite on the RGB cube.
-function useBackgroundColorTween(colorKey: string | undefined, durationMs = 600): string {
-  const target = useMemo(() => resolveSubtleColor(colorKey), [colorKey]);
-  const displayed = useTween(target, { durationMs, interpolate: lerpOklab, isEqual: oklabEqual });
-  return formatRgb(rgb(displayed));
-}
-
-const fillColorStyle = (
-  backgroundColor: string,
-  colorKey: string | undefined,
-): React.CSSProperties => ({
-  backgroundColor,
-  color: colorKey ? `var(--chakra-colors-${colorKey}-fg)` : 'inherit',
-});
 
 const PirateNameCell = React.memo(
   ({ arenaIndex, pirateIndex }: { arenaIndex: number; pirateIndex: number }) => {

--- a/src/app/components/ui/AnimatedNumber.tsx
+++ b/src/app/components/ui/AnimatedNumber.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { useIsStillSettling } from '../../hooks/useIsStillSettling';
 
@@ -7,6 +7,10 @@ import { useTween } from './useTween';
 // this element displays a number that smoothly tweens (counts) from its
 // previous value to a new one whenever the value changes. See useTween for
 // the animation mechanics.
+
+// Last displayed value per persistKey, surviving individual component
+// unmounts (see the persistKey prop below).
+const lastKnownValues = new Map<string, number>();
 
 interface AnimatedNumberProps {
   value: number;
@@ -18,6 +22,14 @@ interface AnimatedNumberProps {
   // (odds, payoffs, maxbets) so the count-up never flickers through decimals
   // and shifts layout.
   precision?: number;
+  // Stable identifier (e.g. "arena0-pirate1-currentOdds") for values whose
+  // owning row can unmount and remount at the same table position - a
+  // different pirate occupying the same slot after a round switch, say.
+  // Without this, a remounted instance has no previous value to animate
+  // from and just snaps straight to the new one. With it, the instance
+  // recovers whatever was last displayed under that key and animates from
+  // there instead.
+  persistKey?: string;
 }
 
 const lerp = (from: number, to: number, t: number): number => from + (to - from) * t;
@@ -30,14 +42,23 @@ const AnimatedNumber = React.memo(
     durationMs = 400,
     className,
     precision,
+    persistKey,
   }: AnimatedNumberProps): React.ReactElement => {
     const isStillSettling = useIsStillSettling();
+    const initialValue = persistKey ? lastKnownValues.get(persistKey) : undefined;
     const displayed = useTween(value, {
       durationMs,
       interpolate: lerp,
       isEqual: numbersEqual,
       instant: isStillSettling,
+      initialValue,
     });
+
+    useEffect(() => {
+      if (persistKey) {
+        lastKnownValues.set(persistKey, displayed);
+      }
+    }, [persistKey, displayed]);
 
     const formatter = format ?? ((v: number): string => v.toLocaleString());
     const formatValue = (v: number): string =>

--- a/src/app/components/ui/AnimatedNumber.tsx
+++ b/src/app/components/ui/AnimatedNumber.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { useIsStillSettling } from '../../hooks/useIsStillSettling';
+
 import { useTween } from './useTween';
 
 // this element displays a number that smoothly tweens (counts) from its
@@ -29,7 +31,13 @@ const AnimatedNumber = React.memo(
     className,
     precision,
   }: AnimatedNumberProps): React.ReactElement => {
-    const displayed = useTween(value, { durationMs, interpolate: lerp, isEqual: numbersEqual });
+    const isStillSettling = useIsStillSettling();
+    const displayed = useTween(value, {
+      durationMs,
+      interpolate: lerp,
+      isEqual: numbersEqual,
+      instant: isStillSettling,
+    });
 
     const formatter = format ?? ((v: number): string => v.toLocaleString());
     const formatValue = (v: number): string =>

--- a/src/app/components/ui/__tests__/AnimatedNumber.test.tsx
+++ b/src/app/components/ui/__tests__/AnimatedNumber.test.tsx
@@ -3,6 +3,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import AnimatedNumber from '../AnimatedNumber';
 
+// These tests exercise the tween mechanics directly, not the "don't
+// animate before the app's first calculation finishes" behavior - treat
+// the app as already settled so value changes tween as they normally
+// would once real data is loaded.
+vi.mock('../../../hooks/useIsStillSettling', () => ({
+  useIsStillSettling: (): boolean => false,
+}));
+
 describe('AnimatedNumber', () => {
   let rafQueue: { id: number; cb: (now: number) => void }[];
   let nextRafId: number;

--- a/src/app/components/ui/__tests__/AnimatedNumber.test.tsx
+++ b/src/app/components/ui/__tests__/AnimatedNumber.test.tsx
@@ -119,6 +119,38 @@ describe('AnimatedNumber', () => {
     expect(screen.getByText('1234.50%')).toBeInTheDocument();
   });
 
+  /**
+   * Regression test: a row can unmount and remount at the same table
+   * position (e.g. a different pirate occupying the same slot after a
+   * round switch) - a fresh AnimatedNumber instance has no history of its
+   * own to tween from and would otherwise just snap straight to the new
+   * value. With a persistKey, it recovers the last value shown under that
+   * key (from whatever instance displayed it last) and animates from
+   * there instead.
+   */
+  it('recovers the last value for a persistKey across an unmount/remount and animates from it', () => {
+    const { unmount } = render(<AnimatedNumber value={20} persistKey="pirate-0-0-currentOdds" />);
+    unmount();
+
+    render(<AnimatedNumber value={24} persistKey="pirate-0-0-currentOdds" />);
+
+    expect(screen.getByText('20')).toBeInTheDocument();
+    expect(rafQueue.length).toBeGreaterThan(0);
+
+    flushFrames(400);
+    expect(screen.getByText('24')).toBeInTheDocument();
+  });
+
+  it('with no persistKey, a fresh instance just shows the new value with nothing to animate from', () => {
+    const { unmount } = render(<AnimatedNumber value={20} />);
+    unmount();
+
+    render(<AnimatedNumber value={24} />);
+
+    expect(screen.getByText('24')).toBeInTheDocument();
+    expect(rafQueue).toHaveLength(0);
+  });
+
   it('jumps instantly when prefers-reduced-motion is set', () => {
     vi.spyOn(window, 'matchMedia').mockImplementation(
       query =>

--- a/src/app/components/ui/__tests__/useBackgroundColorTween.test.tsx
+++ b/src/app/components/ui/__tests__/useBackgroundColorTween.test.tsx
@@ -1,0 +1,112 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useBackgroundColorTween } from '../useBackgroundColorTween';
+
+function TestCell({ colorKey }: { colorKey: string | undefined }): React.ReactElement {
+  // durationMs=0 so the returned color is the resolved target immediately,
+  // isolating the CSS-custom-property retry logic under test from the
+  // color tween's own animation.
+  const bg = useBackgroundColorTween(colorKey, 0);
+  return <div data-testid="cell" style={{ backgroundColor: bg }} />;
+}
+
+/**
+ * Regression test: a pirate whose name-cell color key is 'nfc-green' from
+ * the very first render (the default odds tier) previously stayed stuck
+ * fully transparent forever if the CSS custom property backing that color
+ * wasn't readable on the very first resolve attempt, because the old fix
+ * only re-resolved when colorKey itself changed - which never happens for
+ * a color key that's constant since mount.
+ */
+describe('useBackgroundColorTween', () => {
+  let rafQueue: { id: number; cb: (now: number) => void }[];
+  let nextRafId: number;
+
+  beforeEach(() => {
+    rafQueue = [];
+    nextRafId = 1;
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((cb: (t: number) => void) => {
+        const id = nextRafId++;
+        rafQueue.push({ id, cb });
+        return id;
+      }),
+    );
+    vi.stubGlobal(
+      'cancelAnimationFrame',
+      vi.fn((id: number) => {
+        rafQueue = rafQueue.filter(entry => entry.id !== id);
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  const flushRaf = (times: number): void => {
+    act(() => {
+      for (let i = 0; i < times && rafQueue.length > 0; i++) {
+        const frame = rafQueue.shift()!;
+        frame.cb(0);
+      }
+    });
+  };
+
+  const mockCssVar = (values: Record<string, string[]>): void => {
+    const callCounts: Record<string, number> = {};
+    vi.spyOn(window, 'getComputedStyle').mockImplementation(
+      () =>
+        ({
+          getPropertyValue: (prop: string) => {
+            const queue = values[prop];
+            if (!queue) {
+              return '';
+            }
+            const idx = Math.min(callCounts[prop] ?? 0, queue.length - 1);
+            callCounts[prop] = (callCounts[prop] ?? 0) + 1;
+            return queue[idx] ?? '';
+          },
+        }) as unknown as CSSStyleDeclaration,
+    );
+  };
+
+  it('retries until the CSS custom property resolves, instead of getting stuck transparent', () => {
+    mockCssVar({
+      '--chakra-colors-nfc-green-subtle': ['', '', '#50C17F'],
+    });
+
+    render(<TestCell colorKey="nfc-green" />);
+
+    expect(screen.getByTestId('cell').style.backgroundColor).toBe('rgba(0, 0, 0, 0)');
+    expect(rafQueue.length).toBeGreaterThan(0);
+
+    flushRaf(5);
+
+    expect(screen.getByTestId('cell').style.backgroundColor).toBe('rgb(80, 193, 127)');
+    expect(rafQueue).toHaveLength(0);
+  });
+
+  it('resolves immediately when the CSS custom property is ready on the first read', () => {
+    mockCssVar({
+      '--chakra-colors-nfc-red-subtle': ['#F76C6C'],
+    });
+
+    render(<TestCell colorKey="nfc-red" />);
+
+    expect(screen.getByTestId('cell').style.backgroundColor).toBe('rgb(247, 108, 108)');
+    expect(rafQueue).toHaveLength(0);
+  });
+
+  it('stays transparent without retrying when there is no color key', () => {
+    mockCssVar({});
+
+    render(<TestCell colorKey={undefined} />);
+
+    expect(screen.getByTestId('cell').style.backgroundColor).toBe('rgba(0, 0, 0, 0)');
+    expect(rafQueue).toHaveLength(0);
+  });
+});

--- a/src/app/components/ui/__tests__/useBackgroundColorTween.test.tsx
+++ b/src/app/components/ui/__tests__/useBackgroundColorTween.test.tsx
@@ -1,16 +1,7 @@
 import { act, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { useIsStillSettling } from '../../../hooks/useIsStillSettling';
 import { useBackgroundColorTween } from '../useBackgroundColorTween';
-
-// Most of these tests exercise the CSS-resolution-driven instant logic,
-// not the "app hasn't finished its first calculation yet" gate - default
-// to already settled so colorKey changes tween as they normally would,
-// and override per-test where the settling behavior itself is under test.
-vi.mock('../../../hooks/useIsStillSettling', () => ({
-  useIsStillSettling: vi.fn(() => false),
-}));
 
 function TestCell({ colorKey }: { colorKey: string | undefined }): React.ReactElement {
   // durationMs=0 so the returned color is the resolved target immediately,
@@ -128,24 +119,32 @@ describe('useBackgroundColorTween', () => {
     expect(rafQueue).toHaveLength(0);
   });
 
-  /**
-   * Regression test: establishing a cell's first-ever color (whether on the
-   * very first render or after a few CSS-var retries) must never itself be
-   * a visible animation - only a real colorKey change afterward (e.g. a
-   * pirate winning) should tween. An earlier attempt at this used a global
-   * page-load timer, which incorrectly suppressed genuine changes that
-   * happened to land shortly after mount too (e.g. a fast round switch).
-   */
-  it('snaps to the first resolved color but animates a later genuine colorKey change', () => {
+  it('animates establishing the first color when the CSS var needed a retry to resolve', () => {
+    mockCssVar({
+      '--chakra-colors-nfc-green-subtle': ['', '', '#50C17F'],
+    });
+
+    render(<TestCellAnimated colorKey="nfc-green" />);
+
+    expect(screen.getByTestId('cell').style.backgroundColor).toBe('rgba(0, 0, 0, 0)');
+    expect(rafQueue.length).toBeGreaterThan(0);
+
+    flushRaf(5); // resolve the CSS var, retargeting the tween
+    expect(screen.getByTestId('cell').style.backgroundColor).not.toBe('rgb(80, 193, 127)');
+
+    flushRaf(30);
+    expect(screen.getByTestId('cell').style.backgroundColor).toBe('rgb(80, 193, 127)');
+  });
+
+  it('animates a later genuine colorKey change', () => {
     mockCssVar({
       '--chakra-colors-nfc-green-subtle': ['#50C17F'],
       '--chakra-colors-nfc-red-subtle': ['#F76C6C'],
     });
 
     const { rerender } = render(<TestCellAnimated colorKey="nfc-green" />);
-
+    flushRaf(30);
     expect(screen.getByTestId('cell').style.backgroundColor).toBe('rgb(80, 193, 127)');
-    expect(rafQueue).toHaveLength(0);
 
     rerender(<TestCellAnimated colorKey="nfc-red" />);
 
@@ -153,30 +152,6 @@ describe('useBackgroundColorTween', () => {
     expect(screen.getByTestId('cell').style.backgroundColor).not.toBe('rgb(247, 108, 108)');
 
     flushRaf(30);
-
     expect(screen.getByTestId('cell').style.backgroundColor).toBe('rgb(247, 108, 108)');
-  });
-
-  /**
-   * Regression test: a colorKey driven by calculation-derived data (e.g.
-   * pirateWon, from winningBetBinary) can change from its placeholder
-   * value to the real one only once the round store's first calculation
-   * completes - a moment separate from (and later than) the CSS
-   * resolution covered above. That transition must snap too, not animate
-   * like a genuine mid-session change.
-   */
-  it('snaps a colorKey change while the app is still settling, even if the CSS resolves fine', () => {
-    vi.mocked(useIsStillSettling).mockReturnValue(true);
-
-    mockCssVar({
-      '--chakra-colors-nfc-green-subtle': ['#50C17F'],
-      '--chakra-colors-nfc-red-subtle': ['#F76C6C'],
-    });
-
-    const { rerender } = render(<TestCellAnimated colorKey="nfc-green" />);
-    rerender(<TestCellAnimated colorKey="nfc-red" />);
-
-    expect(screen.getByTestId('cell').style.backgroundColor).toBe('rgb(247, 108, 108)');
-    expect(rafQueue).toHaveLength(0);
   });
 });

--- a/src/app/components/ui/__tests__/useBackgroundColorTween.test.tsx
+++ b/src/app/components/ui/__tests__/useBackgroundColorTween.test.tsx
@@ -1,7 +1,16 @@
 import { act, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useIsStillSettling } from '../../../hooks/useIsStillSettling';
 import { useBackgroundColorTween } from '../useBackgroundColorTween';
+
+// Most of these tests exercise the CSS-resolution-driven instant logic,
+// not the "app hasn't finished its first calculation yet" gate - default
+// to already settled so colorKey changes tween as they normally would,
+// and override per-test where the settling behavior itself is under test.
+vi.mock('../../../hooks/useIsStillSettling', () => ({
+  useIsStillSettling: vi.fn(() => false),
+}));
 
 function TestCell({ colorKey }: { colorKey: string | undefined }): React.ReactElement {
   // durationMs=0 so the returned color is the resolved target immediately,
@@ -146,5 +155,28 @@ describe('useBackgroundColorTween', () => {
     flushRaf(30);
 
     expect(screen.getByTestId('cell').style.backgroundColor).toBe('rgb(247, 108, 108)');
+  });
+
+  /**
+   * Regression test: a colorKey driven by calculation-derived data (e.g.
+   * pirateWon, from winningBetBinary) can change from its placeholder
+   * value to the real one only once the round store's first calculation
+   * completes - a moment separate from (and later than) the CSS
+   * resolution covered above. That transition must snap too, not animate
+   * like a genuine mid-session change.
+   */
+  it('snaps a colorKey change while the app is still settling, even if the CSS resolves fine', () => {
+    vi.mocked(useIsStillSettling).mockReturnValue(true);
+
+    mockCssVar({
+      '--chakra-colors-nfc-green-subtle': ['#50C17F'],
+      '--chakra-colors-nfc-red-subtle': ['#F76C6C'],
+    });
+
+    const { rerender } = render(<TestCellAnimated colorKey="nfc-green" />);
+    rerender(<TestCellAnimated colorKey="nfc-red" />);
+
+    expect(screen.getByTestId('cell').style.backgroundColor).toBe('rgb(247, 108, 108)');
+    expect(rafQueue).toHaveLength(0);
   });
 });

--- a/src/app/components/ui/__tests__/useBackgroundColorTween.test.tsx
+++ b/src/app/components/ui/__tests__/useBackgroundColorTween.test.tsx
@@ -11,6 +11,11 @@ function TestCell({ colorKey }: { colorKey: string | undefined }): React.ReactEl
   return <div data-testid="cell" style={{ backgroundColor: bg }} />;
 }
 
+function TestCellAnimated({ colorKey }: { colorKey: string | undefined }): React.ReactElement {
+  const bg = useBackgroundColorTween(colorKey, 400);
+  return <div data-testid="cell" style={{ backgroundColor: bg }} />;
+}
+
 /**
  * Regression test: a pirate whose name-cell color key is 'nfc-green' from
  * the very first render (the default odds tier) previously stayed stuck
@@ -22,10 +27,12 @@ function TestCell({ colorKey }: { colorKey: string | undefined }): React.ReactEl
 describe('useBackgroundColorTween', () => {
   let rafQueue: { id: number; cb: (now: number) => void }[];
   let nextRafId: number;
+  let now: number;
 
   beforeEach(() => {
     rafQueue = [];
     nextRafId = 1;
+    now = 0;
     vi.stubGlobal(
       'requestAnimationFrame',
       vi.fn((cb: (t: number) => void) => {
@@ -40,6 +47,7 @@ describe('useBackgroundColorTween', () => {
         rafQueue = rafQueue.filter(entry => entry.id !== id);
       }),
     );
+    vi.stubGlobal('performance', { now: () => now });
   });
 
   afterEach(() => {
@@ -47,11 +55,12 @@ describe('useBackgroundColorTween', () => {
     vi.restoreAllMocks();
   });
 
-  const flushRaf = (times: number): void => {
+  const flushRaf = (times: number, step = 16): void => {
     act(() => {
       for (let i = 0; i < times && rafQueue.length > 0; i++) {
         const frame = rafQueue.shift()!;
-        frame.cb(0);
+        now += step;
+        frame.cb(now);
       }
     });
   };
@@ -108,5 +117,34 @@ describe('useBackgroundColorTween', () => {
 
     expect(screen.getByTestId('cell').style.backgroundColor).toBe('rgba(0, 0, 0, 0)');
     expect(rafQueue).toHaveLength(0);
+  });
+
+  /**
+   * Regression test: establishing a cell's first-ever color (whether on the
+   * very first render or after a few CSS-var retries) must never itself be
+   * a visible animation - only a real colorKey change afterward (e.g. a
+   * pirate winning) should tween. An earlier attempt at this used a global
+   * page-load timer, which incorrectly suppressed genuine changes that
+   * happened to land shortly after mount too (e.g. a fast round switch).
+   */
+  it('snaps to the first resolved color but animates a later genuine colorKey change', () => {
+    mockCssVar({
+      '--chakra-colors-nfc-green-subtle': ['#50C17F'],
+      '--chakra-colors-nfc-red-subtle': ['#F76C6C'],
+    });
+
+    const { rerender } = render(<TestCellAnimated colorKey="nfc-green" />);
+
+    expect(screen.getByTestId('cell').style.backgroundColor).toBe('rgb(80, 193, 127)');
+    expect(rafQueue).toHaveLength(0);
+
+    rerender(<TestCellAnimated colorKey="nfc-red" />);
+
+    expect(rafQueue.length).toBeGreaterThan(0);
+    expect(screen.getByTestId('cell').style.backgroundColor).not.toBe('rgb(247, 108, 108)');
+
+    flushRaf(30);
+
+    expect(screen.getByTestId('cell').style.backgroundColor).toBe('rgb(247, 108, 108)');
   });
 });

--- a/src/app/components/ui/useBackgroundColorTween.ts
+++ b/src/app/components/ui/useBackgroundColorTween.ts
@@ -1,7 +1,5 @@
 import { oklab, rgb, formatRgb, type Oklab } from 'culori';
-import { useEffect, useRef, useState, type CSSProperties } from 'react';
-
-import { useIsStillSettling } from '../../hooks/useIsStillSettling';
+import { useEffect, useState, type CSSProperties } from 'react';
 
 import { useTween } from './useTween';
 
@@ -47,21 +45,6 @@ const oklabEqual = (x: Oklab, y: Oklab): boolean =>
 // a muddy midpoint the way a raw RGB lerp would.
 export function useBackgroundColorTween(colorKey: string | undefined, durationMs = 600): string {
   const [target, setTarget] = useState(() => resolveSubtleColor(colorKey) ?? TRANSPARENT);
-  // Whether we've ever successfully resolved a real color for this hook
-  // instance. Until then, any correction is establishing the initial state
-  // (not a visible transition) and should snap instead of animating -
-  // otherwise every cell would visibly fade in from transparent once its
-  // CSS custom property finally resolves.
-  const [cssResolveInstant, setCssResolveInstant] = useState(true);
-  const hasResolvedOnceRef = useRef(false);
-  // colorKey itself can be driven by calculation-derived data (e.g.
-  // pirateWon, from state.calculations.winningBetBinary) that starts
-  // empty/wrong and only becomes real once the round store's first
-  // calculation completes - a moment separate from (and later than) the
-  // CSS resolution above. Without this, that transition would animate
-  // like a genuine mid-session change (e.g. a pirate winning) instead of
-  // snapping like the rest of the initial load.
-  const isStillSettling = useIsStillSettling();
 
   useEffect(() => {
     // The CSS custom property backing this color can still be unset on the
@@ -77,8 +60,6 @@ export function useBackgroundColorTween(colorKey: string | undefined, durationMs
     const tryResolve = (): void => {
       const resolved = resolveSubtleColor(colorKey);
       if (resolved) {
-        setCssResolveInstant(!hasResolvedOnceRef.current);
-        hasResolvedOnceRef.current = true;
         setTarget(resolved);
         return;
       }
@@ -96,12 +77,7 @@ export function useBackgroundColorTween(colorKey: string | undefined, durationMs
     };
   }, [colorKey]);
 
-  const displayed = useTween(target, {
-    durationMs,
-    interpolate: lerpOklab,
-    isEqual: oklabEqual,
-    instant: cssResolveInstant || isStillSettling,
-  });
+  const displayed = useTween(target, { durationMs, interpolate: lerpOklab, isEqual: oklabEqual });
   return formatRgb(rgb(displayed));
 }
 

--- a/src/app/components/ui/useBackgroundColorTween.ts
+++ b/src/app/components/ui/useBackgroundColorTween.ts
@@ -1,5 +1,5 @@
 import { oklab, rgb, formatRgb, type Oklab } from 'culori';
-import { useMemo, type CSSProperties } from 'react';
+import { useEffect, useState, type CSSProperties } from 'react';
 
 import { useTween } from './useTween';
 
@@ -24,20 +24,20 @@ const lerpOklab = (from: Oklab, to: Oklab, t: number): Oklab => ({
 const oklabEqual = (x: Oklab, y: Oklab): boolean =>
   x.l === y.l && x.a === y.a && x.b === y.b && (x.alpha ?? 1) === (y.alpha ?? 1);
 
-// Animates a cell's background color frame-by-frame in JS instead of via a
-// CSS transition, which proved unreliable: cells could get stuck showing a
-// stale color after a round switch even though the DOM's computed style was
-// already correct (a browser repaint bug), and workarounds that forced a
-// repaint afterward either didn't fix it consistently or introduced their
-// own visible glitches. Reuses the same tween mechanics AnimatedNumber uses
-// for numbers.
-//
-// Interpolates in OKLab (a perceptually-uniform color space) rather than raw
-// sRGB - a plain RGB lerp between e.g. nfc-green and nfc-red (a direct
-// win-to-loss flip on the same bet slot) passes through a muddy tan/khaki
-// midpoint, since red and green are near-opposite on the RGB cube.
+// Animates a cell's background color in JS (same tween mechanics as
+// AnimatedNumber) instead of a CSS transition, which proved unreliable.
+// Interpolates in OKLab so e.g. nfc-green <-> nfc-red doesn't pass through
+// a muddy midpoint the way a raw RGB lerp would.
 export function useBackgroundColorTween(colorKey: string | undefined, durationMs = 600): string {
-  const target = useMemo(() => resolveSubtleColor(colorKey), [colorKey]);
+  // Lazy-initialized in case the CSS vars aren't applied yet on the very
+  // first render; the effect below re-resolves post-paint (it also runs
+  // once right after mount, not just on colorKey changes), correcting that
+  // initial read if needed.
+  const [target, setTarget] = useState(() => resolveSubtleColor(colorKey));
+  useEffect(() => {
+    setTarget(resolveSubtleColor(colorKey));
+  }, [colorKey]);
+
   const displayed = useTween(target, { durationMs, interpolate: lerpOklab, isEqual: oklabEqual });
   return formatRgb(rgb(displayed));
 }

--- a/src/app/components/ui/useBackgroundColorTween.ts
+++ b/src/app/components/ui/useBackgroundColorTween.ts
@@ -1,14 +1,16 @@
 import { oklab, rgb, formatRgb, type Oklab } from 'culori';
-import { useEffect, useState, type CSSProperties } from 'react';
+import { useEffect, useRef, useState, type CSSProperties } from 'react';
 
 import { useTween } from './useTween';
 
 const TRANSPARENT: Oklab = { mode: 'oklab', l: 0, a: 0, b: 0, alpha: 0 };
 
-// Safety net so a colorKey that can genuinely never resolve doesn't retry
-// forever - real resolution succeeds within a frame or two once Chakra's
-// stylesheet is in the DOM.
-const MAX_RESOLVE_ATTEMPTS = 30;
+// Safety net so a colorKey that can genuinely never resolve (e.g. a typo'd
+// token that has no CSS custom property at all) doesn't retry forever.
+// Time-based rather than a frame count, since a backgrounded/throttled tab
+// can take far longer than usual to accumulate a handful of animation
+// frames even though resolution would otherwise succeed almost instantly.
+const MAX_RESOLVE_MS = 10_000;
 
 // Returns null (instead of a color) when colorKey is set but the backing CSS
 // custom property can't be read/parsed yet, so callers can tell "off" apart
@@ -43,6 +45,13 @@ const oklabEqual = (x: Oklab, y: Oklab): boolean =>
 // a muddy midpoint the way a raw RGB lerp would.
 export function useBackgroundColorTween(colorKey: string | undefined, durationMs = 600): string {
   const [target, setTarget] = useState(() => resolveSubtleColor(colorKey) ?? TRANSPARENT);
+  // Whether we've ever successfully resolved a real color for this hook
+  // instance. Until then, any correction is establishing the initial state
+  // (not a visible transition) and should snap instead of animating -
+  // otherwise every cell would visibly fade in from transparent once its
+  // CSS custom property finally resolves.
+  const [instant, setInstant] = useState(true);
+  const hasResolvedOnceRef = useRef(false);
 
   useEffect(() => {
     // The CSS custom property backing this color can still be unset on the
@@ -53,16 +62,17 @@ export function useBackgroundColorTween(colorKey: string | undefined, durationMs
     // frames until it actually resolves, instead of getting stuck on one bad
     // read forever.
     let frame: number | null = null;
-    let attempts = 0;
+    const start = window.performance.now();
 
     const tryResolve = (): void => {
       const resolved = resolveSubtleColor(colorKey);
       if (resolved) {
+        setInstant(!hasResolvedOnceRef.current);
+        hasResolvedOnceRef.current = true;
         setTarget(resolved);
         return;
       }
-      attempts += 1;
-      if (attempts < MAX_RESOLVE_ATTEMPTS) {
+      if (window.performance.now() - start < MAX_RESOLVE_MS) {
         frame = window.requestAnimationFrame(tryResolve);
       }
     };
@@ -76,7 +86,12 @@ export function useBackgroundColorTween(colorKey: string | undefined, durationMs
     };
   }, [colorKey]);
 
-  const displayed = useTween(target, { durationMs, interpolate: lerpOklab, isEqual: oklabEqual });
+  const displayed = useTween(target, {
+    durationMs,
+    interpolate: lerpOklab,
+    isEqual: oklabEqual,
+    instant,
+  });
   return formatRgb(rgb(displayed));
 }
 

--- a/src/app/components/ui/useBackgroundColorTween.ts
+++ b/src/app/components/ui/useBackgroundColorTween.ts
@@ -1,0 +1,54 @@
+import { oklab, rgb, formatRgb, type Oklab } from 'culori';
+import { useMemo, type CSSProperties } from 'react';
+
+import { useTween } from './useTween';
+
+const resolveSubtleColor = (colorKey: string | undefined): Oklab => {
+  if (!colorKey || typeof window === 'undefined') {
+    return { mode: 'oklab', l: 0, a: 0, b: 0, alpha: 0 };
+  }
+  const raw = window
+    .getComputedStyle(document.documentElement)
+    .getPropertyValue(`--chakra-colors-${colorKey}-subtle`);
+  return oklab(raw) ?? { mode: 'oklab', l: 0, a: 0, b: 0, alpha: 0 };
+};
+
+const lerpOklab = (from: Oklab, to: Oklab, t: number): Oklab => ({
+  mode: 'oklab',
+  l: (from.l ?? 0) + ((to.l ?? 0) - (from.l ?? 0)) * t,
+  a: (from.a ?? 0) + ((to.a ?? 0) - (from.a ?? 0)) * t,
+  b: (from.b ?? 0) + ((to.b ?? 0) - (from.b ?? 0)) * t,
+  alpha: (from.alpha ?? 1) + ((to.alpha ?? 1) - (from.alpha ?? 1)) * t,
+});
+
+const oklabEqual = (x: Oklab, y: Oklab): boolean =>
+  x.l === y.l && x.a === y.a && x.b === y.b && (x.alpha ?? 1) === (y.alpha ?? 1);
+
+// Animates a cell's background color frame-by-frame in JS instead of via a
+// CSS transition, which proved unreliable: cells could get stuck showing a
+// stale color after a round switch even though the DOM's computed style was
+// already correct (a browser repaint bug), and workarounds that forced a
+// repaint afterward either didn't fix it consistently or introduced their
+// own visible glitches. Reuses the same tween mechanics AnimatedNumber uses
+// for numbers.
+//
+// Interpolates in OKLab (a perceptually-uniform color space) rather than raw
+// sRGB - a plain RGB lerp between e.g. nfc-green and nfc-red (a direct
+// win-to-loss flip on the same bet slot) passes through a muddy tan/khaki
+// midpoint, since red and green are near-opposite on the RGB cube.
+export function useBackgroundColorTween(colorKey: string | undefined, durationMs = 600): string {
+  const target = useMemo(() => resolveSubtleColor(colorKey), [colorKey]);
+  const displayed = useTween(target, { durationMs, interpolate: lerpOklab, isEqual: oklabEqual });
+  return formatRgb(rgb(displayed));
+}
+
+// Cells using useBackgroundColorTween should also apply the "nfc-color-tween"
+// className (see src/index.css) so the global td/th CSS transition doesn't
+// also try to animate between each already-interpolated frame this sets.
+export const fillColorStyle = (
+  backgroundColor: string,
+  colorKey: string | undefined,
+): CSSProperties => ({
+  backgroundColor,
+  color: colorKey ? `var(--chakra-colors-${colorKey}-fg)` : 'inherit',
+});

--- a/src/app/components/ui/useBackgroundColorTween.ts
+++ b/src/app/components/ui/useBackgroundColorTween.ts
@@ -1,6 +1,8 @@
 import { oklab, rgb, formatRgb, type Oklab } from 'culori';
 import { useEffect, useRef, useState, type CSSProperties } from 'react';
 
+import { useIsStillSettling } from '../../hooks/useIsStillSettling';
+
 import { useTween } from './useTween';
 
 const TRANSPARENT: Oklab = { mode: 'oklab', l: 0, a: 0, b: 0, alpha: 0 };
@@ -50,8 +52,16 @@ export function useBackgroundColorTween(colorKey: string | undefined, durationMs
   // (not a visible transition) and should snap instead of animating -
   // otherwise every cell would visibly fade in from transparent once its
   // CSS custom property finally resolves.
-  const [instant, setInstant] = useState(true);
+  const [cssResolveInstant, setCssResolveInstant] = useState(true);
   const hasResolvedOnceRef = useRef(false);
+  // colorKey itself can be driven by calculation-derived data (e.g.
+  // pirateWon, from state.calculations.winningBetBinary) that starts
+  // empty/wrong and only becomes real once the round store's first
+  // calculation completes - a moment separate from (and later than) the
+  // CSS resolution above. Without this, that transition would animate
+  // like a genuine mid-session change (e.g. a pirate winning) instead of
+  // snapping like the rest of the initial load.
+  const isStillSettling = useIsStillSettling();
 
   useEffect(() => {
     // The CSS custom property backing this color can still be unset on the
@@ -67,7 +77,7 @@ export function useBackgroundColorTween(colorKey: string | undefined, durationMs
     const tryResolve = (): void => {
       const resolved = resolveSubtleColor(colorKey);
       if (resolved) {
-        setInstant(!hasResolvedOnceRef.current);
+        setCssResolveInstant(!hasResolvedOnceRef.current);
         hasResolvedOnceRef.current = true;
         setTarget(resolved);
         return;
@@ -90,7 +100,7 @@ export function useBackgroundColorTween(colorKey: string | undefined, durationMs
     durationMs,
     interpolate: lerpOklab,
     isEqual: oklabEqual,
-    instant,
+    instant: cssResolveInstant || isStillSettling,
   });
   return formatRgb(rgb(displayed));
 }

--- a/src/app/components/ui/useBackgroundColorTween.ts
+++ b/src/app/components/ui/useBackgroundColorTween.ts
@@ -3,14 +3,27 @@ import { useEffect, useState, type CSSProperties } from 'react';
 
 import { useTween } from './useTween';
 
-const resolveSubtleColor = (colorKey: string | undefined): Oklab => {
-  if (!colorKey || typeof window === 'undefined') {
-    return { mode: 'oklab', l: 0, a: 0, b: 0, alpha: 0 };
+const TRANSPARENT: Oklab = { mode: 'oklab', l: 0, a: 0, b: 0, alpha: 0 };
+
+// Safety net so a colorKey that can genuinely never resolve doesn't retry
+// forever - real resolution succeeds within a frame or two once Chakra's
+// stylesheet is in the DOM.
+const MAX_RESOLVE_ATTEMPTS = 30;
+
+// Returns null (instead of a color) when colorKey is set but the backing CSS
+// custom property can't be read/parsed yet, so callers can tell "off" apart
+// from "not ready yet" and retry only the latter.
+const resolveSubtleColor = (colorKey: string | undefined): Oklab | null => {
+  if (!colorKey) {
+    return TRANSPARENT;
+  }
+  if (typeof window === 'undefined') {
+    return null;
   }
   const raw = window
     .getComputedStyle(document.documentElement)
     .getPropertyValue(`--chakra-colors-${colorKey}-subtle`);
-  return oklab(raw) ?? { mode: 'oklab', l: 0, a: 0, b: 0, alpha: 0 };
+  return oklab(raw) ?? null;
 };
 
 const lerpOklab = (from: Oklab, to: Oklab, t: number): Oklab => ({
@@ -29,13 +42,38 @@ const oklabEqual = (x: Oklab, y: Oklab): boolean =>
 // Interpolates in OKLab so e.g. nfc-green <-> nfc-red doesn't pass through
 // a muddy midpoint the way a raw RGB lerp would.
 export function useBackgroundColorTween(colorKey: string | undefined, durationMs = 600): string {
-  // Lazy-initialized in case the CSS vars aren't applied yet on the very
-  // first render; the effect below re-resolves post-paint (it also runs
-  // once right after mount, not just on colorKey changes), correcting that
-  // initial read if needed.
-  const [target, setTarget] = useState(() => resolveSubtleColor(colorKey));
+  const [target, setTarget] = useState(() => resolveSubtleColor(colorKey) ?? TRANSPARENT);
+
   useEffect(() => {
-    setTarget(resolveSubtleColor(colorKey));
+    // The CSS custom property backing this color can still be unset on the
+    // very first read - its stylesheet insertion isn't guaranteed to have
+    // run before this effect does. colorKey often never changes again after
+    // mount (e.g. a pirate that's been in the default tier the whole time),
+    // so a single re-read on mount isn't enough: keep retrying on successive
+    // frames until it actually resolves, instead of getting stuck on one bad
+    // read forever.
+    let frame: number | null = null;
+    let attempts = 0;
+
+    const tryResolve = (): void => {
+      const resolved = resolveSubtleColor(colorKey);
+      if (resolved) {
+        setTarget(resolved);
+        return;
+      }
+      attempts += 1;
+      if (attempts < MAX_RESOLVE_ATTEMPTS) {
+        frame = window.requestAnimationFrame(tryResolve);
+      }
+    };
+
+    tryResolve();
+
+    return (): void => {
+      if (frame !== null) {
+        window.cancelAnimationFrame(frame);
+      }
+    };
   }, [colorKey]);
 
   const displayed = useTween(target, { durationMs, interpolate: lerpOklab, isEqual: oklabEqual });

--- a/src/app/components/ui/useTween.ts
+++ b/src/app/components/ui/useTween.ts
@@ -19,14 +19,20 @@ interface UseTweenOptions<T> {
   // as a visible transition. Only gates that one update; later value
   // changes with instant=false animate normally.
   instant?: boolean;
+  // Overrides the value this hook starts displaying at mount, instead of
+  // `value` itself - lets a caller recover a previous reading (e.g. from
+  // an external cache keyed by something more stable than this component
+  // instance) so a fresh mount can animate from where a prior, unmounted
+  // instance left off instead of snapping straight to `value`.
+  initialValue?: T | undefined;
 }
 
 export function useTween<T>(
   value: T,
-  { durationMs = 400, interpolate, isEqual, instant = false }: UseTweenOptions<T>,
+  { durationMs = 400, interpolate, isEqual, instant = false, initialValue }: UseTweenOptions<T>,
 ): T {
-  const [displayed, setDisplayed] = useState(value);
-  const displayedRef = useRef(value);
+  const [displayed, setDisplayed] = useState(initialValue !== undefined ? initialValue : value);
+  const displayedRef = useRef(displayed);
   const frameRef = useRef<number | null>(null);
 
   useEffect(() => {

--- a/src/app/components/ui/useTween.ts
+++ b/src/app/components/ui/useTween.ts
@@ -13,30 +13,17 @@ interface UseTweenOptions<T> {
   durationMs?: number;
   interpolate: (from: T, to: T, t: number) => T;
   isEqual: (a: T, b: T) => boolean;
+  // When true for the render that produces a new `value`, that specific
+  // update is applied immediately instead of animating - e.g. a caller
+  // correcting a placeholder first reading to the real one shouldn't count
+  // as a visible transition. Only gates that one update; later value
+  // changes with instant=false animate normally.
+  instant?: boolean;
 }
-
-// Values often only settle to their real reading a moment after the page
-// loads (CSS custom properties not yet inserted, round data not yet
-// fetched, etc.) - that settling shouldn't be a visible animation, only
-// genuine changes after the app has finished loading should tween. Grace
-// period is measured from module load, which is close enough to page load
-// for this purpose, and comfortably covers both the color hook's CSS-var
-// retry loop and typical round-data fetch times.
-const pageLoadedAt = typeof window !== 'undefined' ? window.performance.now() : 0;
-const INITIAL_LOAD_GRACE_MS = 2000;
-
-// Tests drive their own fake requestAnimationFrame/performance clocks (see
-// AnimatedNumber.test.tsx) that aren't in the same time domain as
-// pageLoadedAt above - opting out under Vitest keeps this grace period from
-// silently turning every animation in those tests into an instant snap.
-const isWithinInitialLoadGrace = (): boolean =>
-  typeof window !== 'undefined' &&
-  !import.meta.env.VITEST &&
-  window.performance.now() - pageLoadedAt < INITIAL_LOAD_GRACE_MS;
 
 export function useTween<T>(
   value: T,
-  { durationMs = 400, interpolate, isEqual }: UseTweenOptions<T>,
+  { durationMs = 400, interpolate, isEqual, instant = false }: UseTweenOptions<T>,
 ): T {
   const [displayed, setDisplayed] = useState(value);
   const displayedRef = useRef(value);
@@ -59,12 +46,7 @@ export function useTween<T>(
 
     const from = displayedRef.current;
 
-    if (
-      prefersReducedMotion ||
-      isEqual(value, from) ||
-      durationMs <= 0 ||
-      isWithinInitialLoadGrace()
-    ) {
+    if (prefersReducedMotion || isEqual(value, from) || durationMs <= 0 || instant) {
       displayedRef.current = value;
       setDisplayed(value);
       return;
@@ -94,7 +76,7 @@ export function useTween<T>(
         frameRef.current = null;
       }
     };
-  }, [value, durationMs, interpolate, isEqual]);
+  }, [value, durationMs, interpolate, isEqual, instant]);
 
   return displayed;
 }

--- a/src/app/components/ui/useTween.ts
+++ b/src/app/components/ui/useTween.ts
@@ -15,6 +15,25 @@ interface UseTweenOptions<T> {
   isEqual: (a: T, b: T) => boolean;
 }
 
+// Values often only settle to their real reading a moment after the page
+// loads (CSS custom properties not yet inserted, round data not yet
+// fetched, etc.) - that settling shouldn't be a visible animation, only
+// genuine changes after the app has finished loading should tween. Grace
+// period is measured from module load, which is close enough to page load
+// for this purpose, and comfortably covers both the color hook's CSS-var
+// retry loop and typical round-data fetch times.
+const pageLoadedAt = typeof window !== 'undefined' ? window.performance.now() : 0;
+const INITIAL_LOAD_GRACE_MS = 2000;
+
+// Tests drive their own fake requestAnimationFrame/performance clocks (see
+// AnimatedNumber.test.tsx) that aren't in the same time domain as
+// pageLoadedAt above - opting out under Vitest keeps this grace period from
+// silently turning every animation in those tests into an instant snap.
+const isWithinInitialLoadGrace = (): boolean =>
+  typeof window !== 'undefined' &&
+  !import.meta.env.VITEST &&
+  window.performance.now() - pageLoadedAt < INITIAL_LOAD_GRACE_MS;
+
 export function useTween<T>(
   value: T,
   { durationMs = 400, interpolate, isEqual }: UseTweenOptions<T>,
@@ -40,7 +59,12 @@ export function useTween<T>(
 
     const from = displayedRef.current;
 
-    if (prefersReducedMotion || isEqual(value, from) || durationMs <= 0) {
+    if (
+      prefersReducedMotion ||
+      isEqual(value, from) ||
+      durationMs <= 0 ||
+      isWithinInitialLoadGrace()
+    ) {
       displayedRef.current = value;
       setDisplayed(value);
       return;

--- a/src/app/hooks/__tests__/useIsStillSettling.test.ts
+++ b/src/app/hooks/__tests__/useIsStillSettling.test.ts
@@ -2,7 +2,7 @@ import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { useRoundStore } from '../../stores';
-import { useIsStillSettling } from '../useIsStillSettling';
+import { useIsStillSettling, __resetIsStillSettlingForTests } from '../useIsStillSettling';
 
 vi.mock('universal-cookie', () => ({
   default: vi.fn().mockImplementation(function () {
@@ -21,6 +21,7 @@ const setCalculated = (calculated: boolean): void => {
 
 describe('useIsStillSettling', () => {
   beforeEach(() => {
+    __resetIsStillSettlingForTests();
     setCalculated(false);
   });
 
@@ -52,5 +53,22 @@ describe('useIsStillSettling', () => {
     act(() => setCalculated(false));
     rerender();
     expect(result.current).toBe(false);
+  });
+
+  /**
+   * Regression test: a row that unmounts and remounts (e.g. a different
+   * pirate occupying the same table slot after a round switch) must not
+   * be treated as settling again just because it's a brand new component
+   * instance - the app already settled once, globally, and that's what
+   * matters for whether the remounted row's first value should animate.
+   */
+  it('is already settled for a component that mounts after the app has settled once', () => {
+    setCalculated(true);
+    const { result: firstMount } = renderHook(() => useIsStillSettling());
+    expect(firstMount.current).toBe(true); // the flip-to-true render itself
+
+    // A brand new hook instance, as if a different component just mounted.
+    const { result: freshMount } = renderHook(() => useIsStillSettling());
+    expect(freshMount.current).toBe(false);
   });
 });

--- a/src/app/hooks/__tests__/useIsStillSettling.test.ts
+++ b/src/app/hooks/__tests__/useIsStillSettling.test.ts
@@ -1,0 +1,56 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { useRoundStore } from '../../stores';
+import { useIsStillSettling } from '../useIsStillSettling';
+
+vi.mock('universal-cookie', () => ({
+  default: vi.fn().mockImplementation(function () {
+    return {
+      get: vi.fn().mockReturnValue(undefined),
+      set: vi.fn(),
+    };
+  }),
+}));
+
+const setCalculated = (calculated: boolean): void => {
+  useRoundStore.setState(state => ({
+    calculations: { ...state.calculations, calculated },
+  }));
+};
+
+describe('useIsStillSettling', () => {
+  beforeEach(() => {
+    setCalculated(false);
+  });
+
+  it('is true before the round store has ever finished a calculation', () => {
+    const { result } = renderHook(() => useIsStillSettling());
+
+    expect(result.current).toBe(true);
+  });
+
+  /**
+   * Regression test: values driven by calculation-derived data (arena
+   * ratios, winningBetBinary-derived colors) start empty/wrong and only
+   * become real once calculated flips true - that transition must itself
+   * still be treated as settling (not a genuine change worth animating),
+   * only changes *after* that should be treated as real.
+   */
+  it('stays true for the render where calculated first flips true, then false from then on', () => {
+    const { result, rerender } = renderHook(() => useIsStillSettling());
+    expect(result.current).toBe(true);
+
+    act(() => setCalculated(true));
+    expect(result.current).toBe(true);
+
+    rerender();
+    expect(result.current).toBe(false);
+
+    // Once settled, it never reverts even if calculated somehow flips
+    // back (e.g. switching to a round with no data).
+    act(() => setCalculated(false));
+    rerender();
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/app/hooks/index.ts
+++ b/src/app/hooks/index.ts
@@ -9,6 +9,7 @@ export { useGetPirateBgColor } from './useGetPirateBgColor';
 export { useInterval } from './useInterval';
 export { useIsMobile } from './useIsMobile';
 export { useIsRoundOver } from './useIsRoundOver';
+export { useIsStillSettling } from './useIsStillSettling';
 export { useOtherTabHasBets } from './useOtherTabHasBets';
 export { useProbabilities } from './useProbabilities';
 export { useRoundProgress } from './useRoundProgress';

--- a/src/app/hooks/useIsStillSettling.ts
+++ b/src/app/hooks/useIsStillSettling.ts
@@ -1,0 +1,21 @@
+import { useRef } from 'react';
+
+import { useIsCalculated } from '../stores';
+
+// True until the round store's calculations have completed at least once,
+// then permanently false - used to snap animated values/colors into place
+// instead of tweening them while the app is still settling into its first
+// real data (arena ratios, winningBetBinary-derived colors, etc. all start
+// empty/undefined and only become trustworthy once calculated flips true).
+// Returns whether calculations were *still incomplete before this render*,
+// so the render where calculated first flips true is itself still treated
+// as settling rather than a genuine change worth animating.
+export function useIsStillSettling(): boolean {
+  const calculated = useIsCalculated();
+  const hasEverCalculatedRef = useRef(false);
+  const wasStillSettling = !hasEverCalculatedRef.current;
+  if (calculated) {
+    hasEverCalculatedRef.current = true;
+  }
+  return wasStillSettling;
+}

--- a/src/app/hooks/useIsStillSettling.ts
+++ b/src/app/hooks/useIsStillSettling.ts
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useEffect } from 'react';
 
 import { useIsCalculated } from '../stores';
 
@@ -10,12 +10,30 @@ import { useIsCalculated } from '../stores';
 // Returns whether calculations were *still incomplete before this render*,
 // so the render where calculated first flips true is itself still treated
 // as settling rather than a genuine change worth animating.
+//
+// Module-level (not a per-component ref): a row that unmounts and remounts
+// later - e.g. a different pirate occupying the same table slot on a round
+// switch - must still see the app as already settled, or its very first
+// post-remount value would wrongly snap instead of animate. The latch is
+// only ever written from an effect (never during render) to stay a pure
+// read from the component's point of view.
+let appHasEverCalculated = false;
+
 export function useIsStillSettling(): boolean {
   const calculated = useIsCalculated();
-  const hasEverCalculatedRef = useRef(false);
-  const wasStillSettling = !hasEverCalculatedRef.current;
-  if (calculated) {
-    hasEverCalculatedRef.current = true;
-  }
+  const wasStillSettling = !appHasEverCalculated;
+
+  useEffect(() => {
+    if (calculated) {
+      appHasEverCalculated = true;
+    }
+  }, [calculated]);
+
   return wasStillSettling;
+}
+
+// Test-only: the module-level latch above is intentionally never reset in
+// the running app, but tests need a clean slate between cases.
+export function __resetIsStillSettlingForTests(): void {
+  appHasEverCalculated = false;
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_GIT_COMMIT_SHA: string;
   readonly DISABLE_REACT_SCAN: string;
+  readonly VITEST?: string;
 }
 
 interface ImportMeta {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,7 +3,6 @@
 interface ImportMetaEnv {
   readonly VITE_GIT_COMMIT_SHA: string;
   readonly DISABLE_REACT_SCAN: string;
-  readonly VITEST?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- Extracts the OKLab color-tween hook from PayoutTable.tsx into a shared `useBackgroundColorTween` module (src/app/components/ui/useBackgroundColorTween.ts) so it can be reused.
- Wraps previously-static numbers (opening odds, logit/legacy probability columns, FA, arena ratio percentages) in `AnimatedNumber`, and moves win/loss background colors (row highlights, name cells, payout cells) to the same JS-driven tween PayoutTable now uses, in both `ArenaTableBody.tsx` and `DropDownTable.tsx`.
- Fixes `StickyTd` silently dropping its sticky positioning when a caller passes a `style` prop (it was spreading the caller's style over its own default instead of merging).

Out of scope (flagged explicitly, not silently skipped):
- The per-food FA indicator text itself (e.g. "+3/-2") - a compound label derived from static per-pirate constants, not a continuously-changing number; only its background color animates.
- `DuplicateBadge` - a discrete on/off indicator.
- `CustomOddsInput`/`CustomProbsInput`'s win-highlight coloring - left on the old CSS-transition approach since converting them would require touching those component files too.