### PR TITLE
Add "New" indicator to Settings accordion and Bet Generation Max Bet setting

### DIFF
--- a/src/app/components/TableSettings/BetGenerationMaxBetToggle.tsx
+++ b/src/app/components/TableSettings/BetGenerationMaxBetToggle.tsx
@@ -1,4 +1,4 @@
-import { HStack } from '@chakra-ui/react';
+import { Badge, HStack, Text } from '@chakra-ui/react';
 import React, { useCallback, useMemo, useRef } from 'react';
 import { FaLock, FaLockOpen } from 'react-icons/fa6';
 import Cookies from 'universal-cookie';
@@ -53,7 +53,14 @@ const BetGenerationMaxBetToggle = (): React.ReactElement => {
   return (
     <SegmentedSettingsRow
       icon={FaLock}
-      label="Bet Generation Max Bet"
+      label={
+        <HStack gap={2}>
+          <Text>Bet Generation Max Bet</Text>
+          <Badge colorPalette="cyan" variant="subtle" size="sm" rounded="full">
+            New
+          </Badge>
+        </HStack>
+      }
       value={mode}
       options={options}
       onChange={persistMode}

--- a/src/app/components/TableSettings/SegmentedSettingsRow.tsx
+++ b/src/app/components/TableSettings/SegmentedSettingsRow.tsx
@@ -8,7 +8,7 @@ interface SegmentedSettingsOption<T extends string> {
 
 interface SegmentedSettingsRowProps<T extends string> {
   icon: ElementType;
-  label: string;
+  label: ReactNode;
   value: T;
   options: SegmentedSettingsOption<T>[];
   onChange: (value: T) => void;

--- a/src/app/components/views/EditBets.tsx
+++ b/src/app/components/views/EditBets.tsx
@@ -1,4 +1,5 @@
 import {
+  Badge,
   Box,
   Button,
   useDisclosure,
@@ -338,6 +339,9 @@ export default React.memo(function EditBets(): React.ReactElement {
                   <Text fontSize="sm" fontWeight="semibold">
                     Settings
                   </Text>
+                  <Badge colorPalette="cyan" variant="subtle" size="sm" rounded="full">
+                    New
+                  </Badge>
                 </HStack>
                 <Accordion.ItemIndicator />
               </Accordion.ItemTrigger>


### PR DESCRIPTION
## Summary
- Adds a small "New" badge next to the Settings accordion header, matching the existing badge style used for the Help Guide link.
- Adds the same "New" badge next to the Bet Generation Max Bet (Capped/Uncapped) setting label, added in #995.