### PR TITLE
Revert "Add "New" indicator to Settings accordion and Bet Generation Max Bet setting" (#998)

### DIFF
--- a/src/app/components/TableSettings/BetGenerationMaxBetToggle.tsx
+++ b/src/app/components/TableSettings/BetGenerationMaxBetToggle.tsx
@@ -1,4 +1,4 @@
-import { Badge, HStack, Text } from '@chakra-ui/react';
+import { HStack } from '@chakra-ui/react';
 import React, { useCallback, useMemo, useRef } from 'react';
 import { FaLock, FaLockOpen } from 'react-icons/fa6';
 import Cookies from 'universal-cookie';
@@ -53,14 +53,7 @@ const BetGenerationMaxBetToggle = (): React.ReactElement => {
   return (
     <SegmentedSettingsRow
       icon={FaLock}
-      label={
-        <HStack gap={2}>
-          <Text>Bet Generation Max Bet</Text>
-          <Badge colorPalette="cyan" variant="subtle" size="sm" rounded="full">
-            New
-          </Badge>
-        </HStack>
-      }
+      label="Bet Generation Max Bet"
       value={mode}
       options={options}
       onChange={persistMode}

--- a/src/app/components/TableSettings/SegmentedSettingsRow.tsx
+++ b/src/app/components/TableSettings/SegmentedSettingsRow.tsx
@@ -8,7 +8,7 @@ interface SegmentedSettingsOption<T extends string> {
 
 interface SegmentedSettingsRowProps<T extends string> {
   icon: ElementType;
-  label: ReactNode;
+  label: string;
   value: T;
   options: SegmentedSettingsOption<T>[];
   onChange: (value: T) => void;

--- a/src/app/components/views/EditBets.tsx
+++ b/src/app/components/views/EditBets.tsx
@@ -1,5 +1,4 @@
 import {
-  Badge,
   Box,
   Button,
   useDisclosure,
@@ -339,9 +338,6 @@ export default React.memo(function EditBets(): React.ReactElement {
                   <Text fontSize="sm" fontWeight="semibold">
                     Settings
                   </Text>
-                  <Badge colorPalette="cyan" variant="subtle" size="sm" rounded="full">
-                    New
-                  </Badge>
                 </HStack>
                 <Accordion.ItemIndicator />
               </Accordion.ItemTrigger>


### PR DESCRIPTION
## Summary
- Reverts the "New" badge changes merged in #998, in case they need to be rolled back.
- This reverts commit c3c0a99.