### PR TITLE
Share a single in-memory cache for previous.jsonl

### DIFF
--- a/src/app/backtest/__tests__/previousRounds.test.ts
+++ b/src/app/backtest/__tests__/previousRounds.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { clearPreviousRoundsFeedCache } from '../../data/previousRoundsFeed';
 import { fetchPreviousRounds } from '../previousRounds';
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  clearPreviousRoundsFeedCache();
 });
 
 describe('fetchPreviousRounds', () => {

--- a/src/app/backtest/previousRounds.ts
+++ b/src/app/backtest/previousRounds.ts
@@ -1,29 +1,17 @@
+import { getPreviousRoundsFeed } from '../data/previousRoundsFeed';
+
 import type { BacktestRound } from './types';
 
 export async function fetchPreviousRounds(
-  signal?: AbortSignal,
+  _signal?: AbortSignal,
+  options?: { forceRefresh?: boolean },
 ): Promise<{ rounds: BacktestRound[]; newestRound: number }> {
-  const response = await fetch('https://cdn.neofood.club/previous.jsonl', {
-    signal: signal ?? null,
-  });
-  const text = await response.text();
-
-  const lines = text
-    .trim()
-    .split('\n')
-    .filter(line => line.trim().length > 0);
+  const lines = await getPreviousRoundsFeed(
+    options?.forceRefresh ? { forceRefresh: true } : undefined,
+  );
 
   const rounds: BacktestRound[] = [];
-  for (const line of lines) {
-    const parsed = JSON.parse(line) as {
-      round: number;
-      pirates: number[][];
-      openingOdds: number[][];
-      currentOdds: number[][];
-      winners?: number[] | null;
-      foods?: number[][] | null;
-    };
-
+  for (const parsed of lines) {
     if (parsed.winners === null || parsed.winners === undefined) {
       continue;
     }

--- a/src/app/data/__tests__/previousRoundsFeed.test.ts
+++ b/src/app/data/__tests__/previousRoundsFeed.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { clearPreviousRoundsFeedCache, getPreviousRoundsFeed } from '../previousRoundsFeed';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  clearPreviousRoundsFeedCache();
+});
+
+function stubFetch(impl: () => Promise<{ text: () => Promise<string> }>): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(impl);
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+describe('getPreviousRoundsFeed', () => {
+  it('parses each line and caches the result across calls', async () => {
+    const lines = [
+      JSON.stringify({ round: 1, pirates: [[1]], openingOdds: [[1]], currentOdds: [[1]] }),
+      JSON.stringify({ round: 2, pirates: [[1]], openingOdds: [[1]], currentOdds: [[1]] }),
+    ];
+    const fetchMock = stubFetch(() =>
+      Promise.resolve({ text: () => Promise.resolve(lines.join('\n')) }),
+    );
+
+    const first = await getPreviousRoundsFeed();
+    const second = await getPreviousRoundsFeed();
+
+    expect(first.map(r => r.round)).toEqual([1, 2]);
+    expect(second).toBe(first);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares a single in-flight fetch between concurrent callers', async () => {
+    const fetchMock = stubFetch(
+      () =>
+        new Promise(resolve => setTimeout(() => resolve({ text: () => Promise.resolve('') }), 0)),
+    );
+
+    const [a, b] = await Promise.all([getPreviousRoundsFeed(), getPreviousRoundsFeed()]);
+
+    expect(a).toEqual(b);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('forceRefresh triggers a new fetch instead of using the cache', async () => {
+    const fetchMock = stubFetch(() => Promise.resolve({ text: () => Promise.resolve('') }));
+
+    await getPreviousRoundsFeed();
+    await getPreviousRoundsFeed({ forceRefresh: true });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips malformed lines instead of throwing', async () => {
+    const lines = [
+      JSON.stringify({ round: 1, pirates: [[1]], openingOdds: [[1]], currentOdds: [[1]] }),
+      'not json',
+    ];
+    stubFetch(() => Promise.resolve({ text: () => Promise.resolve(lines.join('\n')) }));
+
+    const rounds = await getPreviousRoundsFeed();
+
+    expect(rounds.map(r => r.round)).toEqual([1]);
+  });
+
+  it('does not cache a rejected fetch, so a later call can retry', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('network error'))
+      .mockResolvedValueOnce({
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({ round: 1, pirates: [[1]], openingOdds: [[1]], currentOdds: [[1]] }),
+          ),
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(getPreviousRoundsFeed()).rejects.toThrow('network error');
+
+    const rounds = await getPreviousRoundsFeed();
+
+    expect(rounds.map(r => r.round)).toEqual([1]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app/data/previousRoundsFeed.ts
+++ b/src/app/data/previousRoundsFeed.ts
@@ -1,0 +1,58 @@
+export interface RawPreviousRoundLine {
+  round: number;
+  pirates: number[][];
+  openingOdds: number[][];
+  currentOdds: number[][];
+  winners?: number[] | null;
+  foods?: number[][] | null;
+  timestamp?: string | null;
+}
+
+let cachedFeedPromise: Promise<RawPreviousRoundLine[]> | null = null;
+
+async function fetchAndParseFeed(): Promise<RawPreviousRoundLine[]> {
+  const response = await fetch('https://cdn.neofood.club/previous.jsonl');
+  const text = await response.text();
+
+  const lines = text
+    .trim()
+    .split('\n')
+    .filter(line => line.trim().length > 0);
+
+  const rounds: RawPreviousRoundLine[] = [];
+  for (const line of lines) {
+    try {
+      rounds.push(JSON.parse(line) as RawPreviousRoundLine);
+    } catch {
+      continue;
+    }
+  }
+
+  return rounds;
+}
+
+/**
+ * Fetches and parses previous.jsonl (~13MB) at most once per page load and
+ * shares the result across every caller, since the feed is otherwise
+ * downloaded and re-parsed independently by each dev-tool feature that
+ * reads it.
+ */
+export function getPreviousRoundsFeed(options?: {
+  forceRefresh?: boolean;
+}): Promise<RawPreviousRoundLine[]> {
+  if (options?.forceRefresh || cachedFeedPromise === null) {
+    const promise = fetchAndParseFeed();
+    cachedFeedPromise = promise;
+    promise.catch(() => {
+      if (cachedFeedPromise === promise) {
+        cachedFeedPromise = null;
+      }
+    });
+  }
+
+  return cachedFeedPromise;
+}
+
+export function clearPreviousRoundsFeedCache(): void {
+  cachedFeedPromise = null;
+}

--- a/src/app/hooks/useBacktestPreviousRounds.ts
+++ b/src/app/hooks/useBacktestPreviousRounds.ts
@@ -50,11 +50,11 @@ export function useBacktestPreviousRounds({
   const [state, setState] = useState<InternalState>(INITIAL_STATE);
   const hasLoadedRef = useRef<boolean>(false);
 
-  const load = useCallback(async (signal: AbortSignal): Promise<void> => {
+  const load = useCallback(async (signal: AbortSignal, forceRefresh = false): Promise<void> => {
     setState(prev => ({ ...prev, status: 'loading', error: null }));
 
     try {
-      const { rounds, newestRound } = await fetchPreviousRounds(signal);
+      const { rounds, newestRound } = await fetchPreviousRounds(signal, { forceRefresh });
       setState({ status: 'ready', rounds, newestRound, error: null });
     } catch (err) {
       if (isAbortError(err)) {
@@ -78,7 +78,7 @@ export function useBacktestPreviousRounds({
 
   const refetch = useCallback((): void => {
     const controller = new AbortController();
-    void load(controller.signal);
+    void load(controller.signal, true);
   }, [load]);
 
   return {


### PR DESCRIPTION
## Summary
- previous.jsonl (~13MB) is currently fetched and parsed independently by every feature that reads it; only the backtest tool uses it today, but more dev-modal features are coming soon that will need the same data
- Add `src/app/data/previousRoundsFeed.ts`, a module-level cache that fetches and parses the feed once and shares the parsed result with every caller for the lifetime of the page
- `fetchPreviousRounds` now filters/maps over the shared cache instead of doing its own fetch + JSON.parse, and gains a `forceRefresh` option so the existing "Refresh" button in the backtest modal busts the one shared cache instead of just its own local copy