### PR TITLE
Update packageManager to bun 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "foodclub",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "bun@1.3.14",
+  "packageManager": "bun@1.4.0",
   "homepage": "/",
   "dependencies": {
     "@chakra-ui/react": "3.36.1",


### PR DESCRIPTION
## Summary
- CI workflows were already bumped to bun 1.4.0 by renovate (#1002)
- The packageManager field in package.json was left on 1.3.14; this brings it in line with CI