### PR TITLE
Add dev-mode round end-time drift visualizer

### DIFF
--- a/src/app/components/charts/RoundEndDriftChart.tsx
+++ b/src/app/components/charts/RoundEndDriftChart.tsx
@@ -1,0 +1,182 @@
+import { Box, Card } from '@chakra-ui/react';
+import {
+  Chart as ChartJS,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+  TooltipItem,
+} from 'chart.js';
+import annotationPlugin from 'chartjs-plugin-annotation';
+import React, { useMemo } from 'react';
+import { Line } from 'react-chartjs-2';
+
+import { downsampleForChart } from '../../backtest/runBacktest';
+import {
+  SCRAPER_LAG_TOLERANCE_MINUTES,
+  classifyDrift,
+  type DriftPoint,
+  type DriftStatus,
+} from '../../devTiming/drift';
+
+import { useColorMode } from '@/components/ui/color-mode';
+
+ChartJS.register(LinearScale, PointElement, LineElement, Tooltip, Legend, annotationPlugin);
+
+const LINE_COLOR = '#3182ce';
+const LATE_DRIFT_FILL = 'rgba(221, 107, 32, 0.08)';
+const SCRAPER_LAG_FILL = 'rgba(49, 130, 206, 0.10)';
+
+function formatOffset(value: number): string {
+  if (value === 0) {
+    return 'on time';
+  }
+  const sign = value > 0 ? '+' : '\u2212';
+  return `${sign}${Math.abs(value).toFixed(0)} min`;
+}
+
+function statusLabel(status: DriftStatus): string {
+  switch (status) {
+    case 'early':
+      return 'ended early';
+    case 'scraperLag':
+      return 'within scraper-lag window (not drift)';
+    case 'lateDrift':
+      return 'drifted late';
+  }
+}
+
+interface RoundEndDriftChartProps {
+  points: DriftPoint[];
+}
+
+export function RoundEndDriftChart({ points }: RoundEndDriftChartProps): React.JSX.Element {
+  const { colorMode } = useColorMode();
+  const isDarkLikeMode = colorMode !== 'light';
+
+  const rounds = useMemo(() => points.map(p => p.round), [points]);
+  const offsets = useMemo(() => points.map(p => p.offsetMinutes), [points]);
+
+  const chartPoints = useMemo(() => downsampleForChart(offsets, rounds), [offsets, rounds]);
+
+  const data = useMemo(
+    () => ({
+      datasets: [
+        {
+          label: 'End-time offset from 2:15 PM',
+          data: chartPoints,
+          borderColor: LINE_COLOR,
+          backgroundColor: LATE_DRIFT_FILL,
+          pointRadius: points.length > 200 ? 0 : 2,
+          borderWidth: 1.5,
+          fill: false,
+        },
+      ],
+    }),
+    [chartPoints, points.length],
+  );
+
+  const gridColor = isDarkLikeMode ? '#6272a4' : undefined;
+  const textColor = isDarkLikeMode ? '#ffffff' : undefined;
+
+  const options = useMemo(
+    () => ({
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: {
+          display: true,
+          labels: {
+            color: textColor,
+          },
+        },
+        annotation: {
+          annotations: {
+            onTimeLine: {
+              type: 'line' as const,
+              yMin: 0,
+              yMax: 0,
+              borderColor: isDarkLikeMode ? '#a0aec0' : '#718096',
+              borderWidth: 1,
+              borderDash: [4, 4],
+            },
+            scraperLagBand: {
+              type: 'box' as const,
+              yMin: 0,
+              yMax: SCRAPER_LAG_TOLERANCE_MINUTES,
+              backgroundColor: SCRAPER_LAG_FILL,
+              borderWidth: 0,
+            },
+          },
+        },
+        tooltip: {
+          displayColors: false,
+          itemSort: (a: TooltipItem<'line'>, b: TooltipItem<'line'>): number =>
+            (b.parsed.y ?? 0) - (a.parsed.y ?? 0),
+          callbacks: {
+            title: (items: TooltipItem<'line'>[]): string => {
+              const round = items[0]?.parsed.x;
+              return round !== undefined ? `Round ${round}` : '';
+            },
+            label: (context: TooltipItem<'line'>): string[] => {
+              const offset = context.parsed.y ?? 0;
+              return [formatOffset(offset), statusLabel(classifyDrift(offset))];
+            },
+          },
+        },
+      },
+      interaction: {
+        mode: 'index' as const,
+        intersect: false,
+      },
+      animation: {
+        duration: 0,
+      },
+      scales: {
+        x: {
+          type: 'linear' as const,
+          title: {
+            display: true,
+            text: 'Round',
+            color: textColor,
+          },
+          ticks: {
+            color: textColor,
+          },
+          grid: {
+            color: gridColor,
+            borderColor: gridColor,
+          },
+        },
+        y: {
+          title: {
+            display: true,
+            text: 'Offset from 2:15 PM (minutes)',
+            color: textColor,
+          },
+          ticks: {
+            color: textColor,
+            callback: (value: number | string): string => formatOffset(Number(value)),
+          },
+          grid: {
+            color: gridColor,
+            borderColor: gridColor,
+          },
+        },
+      },
+    }),
+    [gridColor, textColor, isDarkLikeMode],
+  );
+
+  return (
+    <Card.Root boxShadow="md">
+      <Card.Body p={2}>
+        <Box w="full" h={{ base: '260px', md: '360px' }}>
+          {/* @ts-ignore */}
+          <Line data={data} options={options} />
+        </Box>
+      </Card.Body>
+    </Card.Root>
+  );
+}

--- a/src/app/components/dev/DevModeDrawer.tsx
+++ b/src/app/components/dev/DevModeDrawer.tsx
@@ -1,12 +1,13 @@
 import { Button, Drawer, Portal, Stack, CloseButton, Separator } from '@chakra-ui/react';
 import * as React from 'react';
-import { FaBalanceScale, FaCode, FaTable } from 'react-icons/fa';
+import { FaBalanceScale, FaCode, FaStopwatch, FaTable } from 'react-icons/fa';
 import { FaMagnifyingGlassChart } from 'react-icons/fa6';
 
 import { useDisclosureState } from '../../hooks/useDisclosureState';
 import { getReactScanEnabled, setReactScanEnabled } from '../../util/reactScan';
 import { AllBetsModal } from '../modals/AllBetsModal';
 import { BacktestComparisonModal } from '../modals/BacktestComparisonModal';
+import { RoundEndDriftModal } from '../modals/RoundEndDriftModal';
 import { RoundJsonModal } from '../modals/RoundJsonModal';
 import SettingsSwitch from '../TableSettings/SettingsSwitch';
 
@@ -19,6 +20,7 @@ export const DevModeDrawer: React.FC<DevModeDrawerProps> = ({ isOpen, onClose })
   const jsonModal = useDisclosureState(false);
   const allBetsModal = useDisclosureState(false);
   const backtestModal = useDisclosureState(false);
+  const driftModal = useDisclosureState(false);
   const [isReactScanEnabled, setIsReactScanEnabled] = React.useState(getReactScanEnabled);
 
   const handleReactScanToggle = React.useCallback((): void => {
@@ -69,6 +71,10 @@ export const DevModeDrawer: React.FC<DevModeDrawerProps> = ({ isOpen, onClose })
                     <FaBalanceScale />
                     Compare Max-TER Models
                   </Button>
+                  <Button width="full" onClick={driftModal.onOpen}>
+                    <FaStopwatch />
+                    Round End-Time Drift
+                  </Button>
                 </Stack>
               </Drawer.Body>
               <Drawer.Footer>
@@ -84,6 +90,7 @@ export const DevModeDrawer: React.FC<DevModeDrawerProps> = ({ isOpen, onClose })
       <RoundJsonModal isOpen={jsonModal.isOpen} onClose={jsonModal.onClose} />
       <AllBetsModal isOpen={allBetsModal.isOpen} onClose={allBetsModal.onClose} />
       <BacktestComparisonModal isOpen={backtestModal.isOpen} onClose={backtestModal.onClose} />
+      <RoundEndDriftModal isOpen={driftModal.isOpen} onClose={driftModal.onClose} />
     </>
   );
 };

--- a/src/app/components/modals/RoundEndDriftModal.tsx
+++ b/src/app/components/modals/RoundEndDriftModal.tsx
@@ -1,0 +1,237 @@
+import {
+  Button,
+  CloseButton,
+  Dialog,
+  HStack,
+  Input,
+  Portal,
+  SimpleGrid,
+  Stack,
+  Text,
+} from '@chakra-ui/react';
+import * as React from 'react';
+
+import { computeDrift, summarizeDrift, type DriftPoint } from '../../devTiming/drift';
+import { useRoundTiming } from '../../devTiming/useRoundTiming';
+import { RoundEndDriftChart } from '../charts/RoundEndDriftChart';
+
+interface RoundEndDriftModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+type RangePreset = 'last30' | 'last100' | 'last500' | 'all';
+
+const RANGE_PRESETS: { value: RangePreset; label: string; count: number | null }[] = [
+  { value: 'last30', label: 'Last 30', count: 30 },
+  { value: 'last100', label: 'Last 100', count: 100 },
+  { value: 'last500', label: 'Last 500', count: 500 },
+  { value: 'all', label: 'All', count: null },
+];
+
+function formatOffsetMinutes(value: number | null): string {
+  if (value === null) {
+    return '\u2014';
+  }
+  if (value === 0) {
+    return 'on time';
+  }
+  const sign = value > 0 ? '+' : '\u2212';
+  return `${sign}${Math.abs(value).toFixed(1)} min`;
+}
+
+export function RoundEndDriftModal({
+  isOpen,
+  onClose,
+}: RoundEndDriftModalProps): React.JSX.Element {
+  const timing = useRoundTiming({ enabled: isOpen });
+
+  const [rangePreset, setRangePreset] = React.useState<RangePreset>('all');
+  const [minRoundInput, setMinRoundInput] = React.useState('');
+  const [maxRoundInput, setMaxRoundInput] = React.useState('');
+
+  const allPoints = React.useMemo<DriftPoint[]>(() => {
+    if (timing.status !== 'ready') {
+      return [];
+    }
+    return computeDrift(timing.timings);
+  }, [timing.status, timing.timings]);
+
+  const visiblePoints = React.useMemo<DriftPoint[]>(() => {
+    if (allPoints.length === 0) {
+      return [];
+    }
+
+    const min = parseInt(minRoundInput, 10);
+    const max = parseInt(maxRoundInput, 10);
+    const hasCustomRange = !Number.isNaN(min) || !Number.isNaN(max);
+
+    if (hasCustomRange) {
+      return allPoints.filter(point => {
+        const aboveMin = Number.isNaN(min) || point.round >= min;
+        const belowMax = Number.isNaN(max) || point.round <= max;
+        return aboveMin && belowMax;
+      });
+    }
+
+    const preset = RANGE_PRESETS.find(p => p.value === rangePreset);
+    if (preset && preset.count !== null) {
+      return allPoints.slice(-preset.count);
+    }
+    return allPoints;
+  }, [allPoints, rangePreset, minRoundInput, maxRoundInput]);
+
+  const summary = React.useMemo(() => summarizeDrift(visiblePoints), [visiblePoints]);
+
+  const statusText = React.useMemo(() => {
+    if (timing.status === 'loading') {
+      return 'Downloading previous.jsonl (~13MB)...';
+    }
+    if (timing.status === 'error') {
+      return timing.error ?? 'Failed to load round history.';
+    }
+    if (timing.status === 'ready') {
+      return `${allPoints.length} rounds with end times loaded.`;
+    }
+    return '';
+  }, [timing.status, timing.error, allPoints.length]);
+
+  const handlePresetClick = React.useCallback((preset: RangePreset): void => {
+    setRangePreset(preset);
+    // A preset supersedes any custom bounds.
+    setMinRoundInput('');
+    setMaxRoundInput('');
+  }, []);
+
+  return (
+    <Dialog.Root
+      open={isOpen}
+      onOpenChange={(e: { open: boolean }) => !e.open && onClose()}
+      size="cover"
+      preventScroll
+      modal
+    >
+      <Portal>
+        <Dialog.Backdrop />
+        <Dialog.Positioner>
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>Round End-Time Drift</Dialog.Title>
+              <Dialog.CloseTrigger asChild>
+                <CloseButton size="sm" />
+              </Dialog.CloseTrigger>
+            </Dialog.Header>
+            <Dialog.Body display="flex" flexDirection="column" overflowY="auto">
+              <Stack gap={4}>
+                <Text fontSize="sm" color="fg.muted">
+                  Plots how far each round&apos;s actual end time (when winners post) drifted from
+                  the expected 2:15 PM Pacific. The shaded band at the bottom is the 0&ndash;2
+                  minute window - ends in that range are just scraper lag, not drift.
+                </Text>
+
+                <HStack justify="space-between" flexWrap="wrap" gap={2}>
+                  <Text fontSize="sm" color="fg.muted">
+                    {statusText}
+                  </Text>
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    onClick={() => timing.refetch()}
+                    disabled={timing.status === 'loading'}
+                  >
+                    Refresh
+                  </Button>
+                </HStack>
+
+                <Stack gap={2}>
+                  <Text fontSize="sm" fontWeight="medium">
+                    Range:
+                  </Text>
+                  <HStack gap={2} flexWrap="wrap">
+                    {RANGE_PRESETS.map(preset => (
+                      <Button
+                        key={preset.value}
+                        size="xs"
+                        variant={
+                          rangePreset === preset.value && !minRoundInput && !maxRoundInput
+                            ? 'solid'
+                            : 'outline'
+                        }
+                        onClick={() => handlePresetClick(preset.value)}
+                      >
+                        {preset.label}
+                      </Button>
+                    ))}
+                  </HStack>
+                  <HStack gap={2}>
+                    <Input
+                      type="number"
+                      placeholder="Min round"
+                      value={minRoundInput}
+                      onChange={e => setMinRoundInput(e.target.value)}
+                      width="120px"
+                      size="sm"
+                    />
+                    <Text fontSize="sm" color="fg.muted">
+                      to
+                    </Text>
+                    <Input
+                      type="number"
+                      placeholder="Max round"
+                      value={maxRoundInput}
+                      onChange={e => setMaxRoundInput(e.target.value)}
+                      width="120px"
+                      size="sm"
+                    />
+                  </HStack>
+                </Stack>
+
+                {timing.status === 'ready' && visiblePoints.length > 0 && (
+                  <>
+                    <SimpleGrid columns={{ base: 2, md: 4 }} gap={3}>
+                      <SummaryStat label="Rounds in range" value={String(visiblePoints.length)} />
+                      <SummaryStat
+                        label="Drifted late (>2 min)"
+                        value={String(summary.countLateDrift)}
+                      />
+                      <SummaryStat label="Ended early" value={String(summary.countEarly)} />
+                      <SummaryStat
+                        label="Most delayed"
+                        value={
+                          summary.mostDelayedRound !== null && summary.maxOffsetMinutes !== null
+                            ? `#${summary.mostDelayedRound} (${formatOffsetMinutes(summary.maxOffsetMinutes)})`
+                            : '\u2014'
+                        }
+                      />
+                    </SimpleGrid>
+
+                    <RoundEndDriftChart points={visiblePoints} />
+                  </>
+                )}
+
+                {timing.status === 'ready' && visiblePoints.length === 0 && (
+                  <Text fontSize="sm" color="fg.muted">
+                    No rounds in the selected range.
+                  </Text>
+                )}
+              </Stack>
+            </Dialog.Body>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+    </Dialog.Root>
+  );
+}
+
+function SummaryStat({ label, value }: { label: string; value: string }): React.JSX.Element {
+  return (
+    <Stack gap={1}>
+      <Text fontSize="xs" color="fg.muted">
+        {label}
+      </Text>
+      <Text fontSize="md" fontWeight="medium">
+        {value}
+      </Text>
+    </Stack>
+  );
+}

--- a/src/app/devTiming/__tests__/drift.test.ts
+++ b/src/app/devTiming/__tests__/drift.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  SCRAPER_LAG_TOLERANCE_MINUTES,
+  classifyDrift,
+  computeDrift,
+  computeOffsetMinutes,
+  expectedEndUtcFor,
+  summarizeDrift,
+} from '../drift';
+
+describe('expectedEndUtcFor', () => {
+  it('is DST-aware: a summer and winter end at the same Pacific wall-clock time map to different UTC instants', () => {
+    const summer = new Date('2026-08-15T21:15:00Z'); // 2:15 PM PDT
+    const winter = new Date('2026-01-15T22:15:00Z'); // 2:15 PM PST
+
+    expect(expectedEndUtcFor(summer).getTime()).toBe(new Date('2026-08-15T21:15:00Z').getTime());
+    expect(expectedEndUtcFor(winter).getTime()).toBe(new Date('2026-01-15T22:15:00Z').getTime());
+  });
+
+  it('anchors to the Pacific date of the actual end, not the UTC date', () => {
+    // 2026-08-15T07:15:00Z is 12:15 AM PDT on Aug 15 - same Pacific day.
+    const lateNight = new Date('2026-08-15T07:15:00Z');
+    expect(expectedEndUtcFor(lateNight).getTime()).toBe(new Date('2026-08-15T21:15:00Z').getTime());
+  });
+});
+
+describe('computeOffsetMinutes', () => {
+  it('is ~0 when the round ends exactly at the expected time (summer)', () => {
+    expect(computeOffsetMinutes(new Date('2026-08-15T21:15:00Z'))).toBeCloseTo(0, 3);
+  });
+
+  it('is ~0 when the round ends exactly at the expected time (winter)', () => {
+    expect(computeOffsetMinutes(new Date('2026-01-15T22:15:00Z'))).toBeCloseTo(0, 3);
+  });
+
+  it('is positive when the round ends late', () => {
+    // 2:17 PM PDT = +2 min.
+    expect(computeOffsetMinutes(new Date('2026-08-15T21:17:00Z'))).toBeCloseTo(2, 3);
+    // 5:15 PM PDT = +3 hours.
+    expect(computeOffsetMinutes(new Date('2026-08-15T00:15:00Z'))).toBeCloseTo(180, 3);
+  });
+
+  it('is negative when the round ends early', () => {
+    // 2:10 PM PDT = -5 min.
+    expect(computeOffsetMinutes(new Date('2026-08-15T21:10:00Z'))).toBeCloseTo(-5, 3);
+  });
+});
+
+describe('classifyDrift', () => {
+  it('treats ends up to and including the tolerance as scraper lag, not drift', () => {
+    expect(classifyDrift(0)).toBe('scraperLag');
+    expect(classifyDrift(SCRAPER_LAG_TOLERANCE_MINUTES)).toBe('scraperLag');
+    expect(classifyDrift(1.5)).toBe('scraperLag');
+  });
+
+  it('treats anything just past the tolerance as late drift', () => {
+    expect(classifyDrift(SCRAPER_LAG_TOLERANCE_MINUTES + 0.01)).toBe('lateDrift');
+    expect(classifyDrift(30)).toBe('lateDrift');
+  });
+
+  it('treats anything before the expected time as early', () => {
+    expect(classifyDrift(-0.01)).toBe('early');
+    expect(classifyDrift(-60)).toBe('early');
+  });
+});
+
+describe('computeDrift', () => {
+  it('skips rows with unparseable timestamps and classifies the rest', () => {
+    const points = computeDrift([
+      { round: 1, timestamp: '2026-08-15T21:15:30Z' }, // +0.5 min -> scraperLag
+      { round: 2, timestamp: 'not-a-date' }, // skipped
+      { round: 3, timestamp: '2026-08-15T22:45:00Z' }, // +90 min -> lateDrift
+      { round: 4, timestamp: '2026-08-15T21:00:00Z' }, // -15 min -> early
+    ]);
+
+    expect(points.map(p => p.round)).toEqual([1, 3, 4]);
+    expect(points[0]!.status).toBe('scraperLag');
+    expect(points[1]!.status).toBe('lateDrift');
+    expect(points[2]!.status).toBe('early');
+    expect(points[1]!.offsetMinutes).toBeCloseTo(90, 3);
+  });
+
+  it('returns an empty array for no input', () => {
+    expect(computeDrift([])).toEqual([]);
+  });
+});
+
+describe('summarizeDrift', () => {
+  it('counts statuses and finds the most delayed round', () => {
+    const points = computeDrift([
+      { round: 1, timestamp: '2026-08-15T21:15:30Z' }, // scraperLag
+      { round: 2, timestamp: '2026-08-15T23:45:00Z' }, // +150 min lateDrift
+      { round: 3, timestamp: '2026-08-15T22:45:00Z' }, // +90 min lateDrift
+      { round: 4, timestamp: '2026-08-15T21:00:00Z' }, // early
+    ]);
+
+    const summary = summarizeDrift(points);
+    expect(summary.countEarly).toBe(1);
+    expect(summary.countScraperLag).toBe(1);
+    expect(summary.countLateDrift).toBe(2);
+    expect(summary.mostDelayedRound).toBe(2);
+    expect(summary.maxOffsetMinutes).toBeCloseTo(150, 3);
+  });
+
+  it('reports null for the most-delayed fields when nothing ended late', () => {
+    const points = computeDrift([
+      { round: 1, timestamp: '2026-08-15T21:15:30Z' }, // scraperLag
+      { round: 2, timestamp: '2026-08-15T21:00:00Z' }, // early
+    ]);
+
+    const summary = summarizeDrift(points);
+    expect(summary.mostDelayedRound).toBeNull();
+    expect(summary.maxOffsetMinutes).toBeNull();
+  });
+});

--- a/src/app/devTiming/__tests__/roundTiming.test.ts
+++ b/src/app/devTiming/__tests__/roundTiming.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { clearPreviousRoundsFeedCache } from '../../data/previousRoundsFeed';
+import { fetchRoundTiming } from '../roundTiming';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  clearPreviousRoundsFeedCache();
+});
+
+function stubFetch(text: string): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      text: () => Promise.resolve(text),
+    }),
+  );
+}
+
+describe('fetchRoundTiming', () => {
+  it('keeps only rounds that have a valid timestamp and sorts them by round', async () => {
+    const lines = [
+      JSON.stringify({ round: 3, timestamp: '2026-08-15T21:15:00Z', winners: [1, 2, 3] }),
+      JSON.stringify({ round: 1, timestamp: '2026-08-13T21:15:00Z' }),
+      JSON.stringify({ round: 2, winners: [1, 1, 1] }), // no timestamp -> dropped
+      JSON.stringify({ round: 5, timestamp: 'not-a-date' }), // invalid -> dropped
+    ];
+
+    stubFetch(lines.join('\n'));
+
+    const timings = await fetchRoundTiming();
+    expect(timings.map(t => t.round)).toEqual([1, 3]);
+    expect(timings[0]!.timestamp).toBe('2026-08-13T21:15:00Z');
+  });
+
+  it('returns an empty array when the feed has no timestamped rounds', async () => {
+    stubFetch(`${JSON.stringify({ round: 1 })}\n${JSON.stringify({ round: 2, winners: null })}`);
+
+    const timings = await fetchRoundTiming();
+    expect(timings).toEqual([]);
+  });
+
+  it('returns an empty array for a blank feed', async () => {
+    stubFetch('');
+
+    const timings = await fetchRoundTiming();
+    expect(timings).toEqual([]);
+  });
+
+  it('reuses the shared feed cache by default and refetches when forceRefresh is set', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      text: () => Promise.resolve(JSON.stringify({ round: 1, timestamp: '2026-08-13T21:15:00Z' })),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchRoundTiming();
+    await fetchRoundTiming();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const refreshed = await fetchRoundTiming(undefined, { forceRefresh: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(refreshed.map(t => t.round)).toEqual([1]);
+  });
+});

--- a/src/app/devTiming/drift.ts
+++ b/src/app/devTiming/drift.ts
@@ -1,0 +1,120 @@
+import { fromZonedTime, toZonedTime } from 'date-fns-tz';
+
+import type { RoundTiming } from './roundTiming';
+
+export const PACIFIC_TIMEZONE = 'America/Los_Angeles';
+export const EXPECTED_END_HOUR = 14;
+export const EXPECTED_END_MINUTE = 15;
+
+/**
+ * The scraper doesn't post winners instantly, so an end time up to this many
+ * minutes after the expected 2:15 PM is treated as normal scraper lag, not
+ * drift.
+ */
+export const SCRAPER_LAG_TOLERANCE_MINUTES = 2;
+
+export type DriftStatus = 'early' | 'scraperLag' | 'lateDrift';
+
+export interface DriftPoint {
+  round: number;
+  timestamp: string;
+  offsetMinutes: number;
+  status: DriftStatus;
+}
+
+export interface DriftSummary {
+  countEarly: number;
+  countScraperLag: number;
+  countLateDrift: number;
+  mostDelayedRound: number | null;
+  maxOffsetMinutes: number | null;
+}
+
+/**
+ * Builds the expected end-of-round instant (2:15 PM Pacific, DST-aware) for
+ * whichever day the given actual end time falls on. `toZonedTime` returns a
+ * Date whose wall-clock fields are the Pacific time of that instant, so we can
+ * read off its local date and construct 2:15 PM on that same day.
+ */
+export function expectedEndUtcFor(actualEndUtc: Date): Date {
+  const zoned = toZonedTime(actualEndUtc, PACIFIC_TIMEZONE);
+  return fromZonedTime(
+    new Date(
+      zoned.getFullYear(),
+      zoned.getMonth(),
+      zoned.getDate(),
+      EXPECTED_END_HOUR,
+      EXPECTED_END_MINUTE,
+    ),
+    PACIFIC_TIMEZONE,
+  );
+}
+
+export function computeOffsetMinutes(actualEndUtc: Date): number {
+  return (actualEndUtc.getTime() - expectedEndUtcFor(actualEndUtc).getTime()) / 60_000;
+}
+
+export function classifyDrift(offsetMinutes: number): DriftStatus {
+  if (offsetMinutes < 0) {
+    return 'early';
+  }
+  if (offsetMinutes <= SCRAPER_LAG_TOLERANCE_MINUTES) {
+    return 'scraperLag';
+  }
+  return 'lateDrift';
+}
+
+export function computeDrift(timings: RoundTiming[]): DriftPoint[] {
+  const points: DriftPoint[] = [];
+
+  for (const timing of timings) {
+    const actualEndUtc = new Date(timing.timestamp);
+    if (Number.isNaN(actualEndUtc.getTime())) {
+      continue;
+    }
+
+    const offsetMinutes = computeOffsetMinutes(actualEndUtc);
+    points.push({
+      round: timing.round,
+      timestamp: timing.timestamp,
+      offsetMinutes,
+      status: classifyDrift(offsetMinutes),
+    });
+  }
+
+  return points;
+}
+
+export function summarizeDrift(points: DriftPoint[]): DriftSummary {
+  let countEarly = 0;
+  let countScraperLag = 0;
+  let countLateDrift = 0;
+  let mostDelayedRound: number | null = null;
+  let maxOffsetMinutes: number | null = null;
+
+  for (const point of points) {
+    switch (point.status) {
+      case 'early':
+        countEarly += 1;
+        break;
+      case 'scraperLag':
+        countScraperLag += 1;
+        break;
+      case 'lateDrift':
+        countLateDrift += 1;
+        if (maxOffsetMinutes === null || point.offsetMinutes > maxOffsetMinutes) {
+          maxOffsetMinutes = point.offsetMinutes;
+          mostDelayedRound = point.round;
+        }
+        break;
+    }
+  }
+
+  return {
+    countEarly,
+    countScraperLag,
+    countLateDrift,
+    mostDelayedRound,
+    maxOffsetMinutes,
+  };
+}

--- a/src/app/devTiming/roundTiming.ts
+++ b/src/app/devTiming/roundTiming.ts
@@ -1,0 +1,41 @@
+import { getPreviousRoundsFeed, type RawPreviousRoundLine } from '../data/previousRoundsFeed';
+
+export interface RoundTiming {
+  round: number;
+  timestamp: string;
+}
+
+function extractRoundTimings(lines: RawPreviousRoundLine[]): RoundTiming[] {
+  const rounds: RoundTiming[] = [];
+
+  for (const line of lines) {
+    if (typeof line.round !== 'number' || typeof line.timestamp !== 'string') {
+      continue;
+    }
+
+    const t = new Date(line.timestamp);
+    if (Number.isNaN(t.getTime())) {
+      continue;
+    }
+
+    rounds.push({ round: line.round, timestamp: line.timestamp });
+  }
+
+  rounds.sort((a, b) => a.round - b.round);
+  return rounds;
+}
+
+/**
+ * Returns the end timestamp of every round that has one, read from the shared
+ * previous.jsonl cache (downloaded at most once per page load unless a refresh
+ * is forced).
+ */
+export async function fetchRoundTiming(
+  _signal?: AbortSignal,
+  options?: { forceRefresh?: boolean },
+): Promise<RoundTiming[]> {
+  const lines = await getPreviousRoundsFeed(
+    options?.forceRefresh ? { forceRefresh: true } : undefined,
+  );
+  return extractRoundTimings(lines);
+}

--- a/src/app/devTiming/useRoundTiming.ts
+++ b/src/app/devTiming/useRoundTiming.ts
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { fetchRoundTiming, type RoundTiming } from './roundTiming';
+
+export type RoundTimingFetchStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+export interface UseRoundTimingResult {
+  status: RoundTimingFetchStatus;
+  timings: RoundTiming[];
+  error: string | null;
+  refetch: () => void;
+}
+
+interface InternalState {
+  status: RoundTimingFetchStatus;
+  timings: RoundTiming[];
+  error: string | null;
+}
+
+const INITIAL_STATE: InternalState = {
+  status: 'idle',
+  timings: [],
+  error: null,
+};
+
+function isAbortError(err: unknown): boolean {
+  if (err instanceof DOMException && err.name === 'AbortError') {
+    return true;
+  }
+  return (
+    typeof err === 'object' && err !== null && (err as { name?: string }).name === 'AbortError'
+  );
+}
+
+/**
+ * Fetches per-round end timestamps for the drift visualizer and holds them in
+ * memory for the lifetime of the page (the drawer/modal that owns this hook
+ * never unmounts, so reopening the tool doesn't refetch). No persistence
+ * across page reloads is intended - a reload starts fresh.
+ */
+export function useRoundTiming({ enabled }: { enabled: boolean }): UseRoundTimingResult {
+  const [state, setState] = useState<InternalState>(INITIAL_STATE);
+  const hasLoadedRef = useRef<boolean>(false);
+
+  const load = useCallback(async (signal: AbortSignal, forceRefresh = false): Promise<void> => {
+    setState(prev => ({ ...prev, status: 'loading', error: null }));
+
+    try {
+      const timings = await fetchRoundTiming(signal, { forceRefresh });
+      setState({ status: 'ready', timings, error: null });
+    } catch (err) {
+      if (isAbortError(err)) {
+        return;
+      }
+      setState({ status: 'error', timings: [], error: String(err) });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || hasLoadedRef.current) {
+      return undefined;
+    }
+    hasLoadedRef.current = true;
+    const controller = new AbortController();
+    void load(controller.signal);
+    return (): void => {
+      controller.abort();
+    };
+  }, [enabled, load]);
+
+  const refetch = useCallback((): void => {
+    const controller = new AbortController();
+    void load(controller.signal, true);
+  }, [load]);
+
+  return {
+    status: state.status,
+    timings: state.timings,
+    error: state.error,
+    refetch,
+  };
+}


### PR DESCRIPTION
## What
Round end times (when winners post) regularly drift from the expected 2:15 PM Pacific, so this adds a dev-only chart showing how far each round's actual end time landed relative to it. Per the agreed rule, ends within 2 minutes **after** the expected time are treated as normal scraper lag (the scraper not scraping immediately), not drift.

## Changes
- New **Round End-Time Drift** button in the Dev Mode drawer (dev-only, gated like the other tools)
- Modal with range presets (Last 30 / Last 100 / Last 500 / All) plus custom min/max round bounds, and summary stats (rounds in range, drifted-late count, early count, most delayed round + offset)
- Chart.js line plot of **offset from 2:15 PM in minutes** per round, with a shaded 0–2 min scraper-lag band and an on-time reference line; offset math is DST-aware (America/Los_Angeles)
- Timestamps are read from the **shared previous.jsonl cache** (`getPreviousRoundsFeed`) rather than fetched independently; Refresh forces a re-download
- Unit tests for the drift math (DST-awareness, classification boundaries) and the fetcher/filtering

## Why it's useful
The live data shows this drift is real and recent: end times drifted upward from ~3 PM (2017) to ~4:45 PM (mid-2025), snapped to exactly 2:15 PM, and the last several rounds are drifting late again (up to +3h). The chart makes that visible at a glance.