### PR TITLE
Add pirate head-to-head matchup tool to dev modal

### DIFF
--- a/src/app/components/charts/MatchupArenaBarChart.tsx
+++ b/src/app/components/charts/MatchupArenaBarChart.tsx
@@ -1,0 +1,100 @@
+import { Box, Card } from '@chakra-ui/react';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Tooltip,
+  Legend,
+  TooltipItem,
+} from 'chart.js';
+import React, { useMemo } from 'react';
+import { Bar } from 'react-chartjs-2';
+
+import { ARENA_NAMES } from '../../constants';
+import type { ArenaMatchupBreakdown } from '../../matchup/pirateMatchups';
+
+import { MATCHUP_A_COLOR, MATCHUP_B_COLOR, MATCHUP_NEITHER_COLOR } from './MatchupSplitDoughnut';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+
+interface MatchupArenaBarChartProps {
+  aName: string;
+  bName: string;
+  breakdown: ArenaMatchupBreakdown[];
+}
+
+export function MatchupArenaBarChart({
+  aName,
+  bName,
+  breakdown,
+}: MatchupArenaBarChartProps): React.JSX.Element {
+  const data = useMemo(
+    () => ({
+      labels: ARENA_NAMES.map(name => name),
+      datasets: [
+        {
+          label: `${aName} won`,
+          data: breakdown.map(row => row.aWins),
+          backgroundColor: MATCHUP_A_COLOR,
+        },
+        {
+          label: `${bName} won`,
+          data: breakdown.map(row => row.bWins),
+          backgroundColor: MATCHUP_B_COLOR,
+        },
+        {
+          label: 'Neither',
+          data: breakdown.map(row => row.neitherCount),
+          backgroundColor: MATCHUP_NEITHER_COLOR,
+        },
+      ],
+    }),
+    [aName, bName, breakdown],
+  );
+
+  const options = useMemo(
+    () => ({
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: {
+          position: 'bottom' as const,
+        },
+        tooltip: {
+          itemSort: (a: TooltipItem<'bar'>, b: TooltipItem<'bar'>): number =>
+            (b.parsed.y ?? 0) - (a.parsed.y ?? 0),
+          callbacks: {
+            title: (items: TooltipItem<'bar'>[]): string => {
+              const label = items[0]?.label;
+              return label ? `${label} arena` : '';
+            },
+          },
+        },
+      },
+      scales: {
+        x: {
+          stacked: true,
+          grid: { display: false },
+        },
+        y: {
+          stacked: true,
+          beginAtZero: true,
+          ticks: { precision: 0 },
+        },
+      },
+    }),
+    [],
+  );
+
+  return (
+    <Card.Root boxShadow="md">
+      <Card.Body p={2}>
+        <Box w="full" h={{ base: '240px', md: '280px' }}>
+          {/* @ts-ignore */}
+          <Bar data={data} options={options} />
+        </Box>
+      </Card.Body>
+    </Card.Root>
+  );
+}

--- a/src/app/components/charts/MatchupSplitDoughnut.tsx
+++ b/src/app/components/charts/MatchupSplitDoughnut.tsx
@@ -1,0 +1,79 @@
+import { Box, Card } from '@chakra-ui/react';
+import { Chart as ChartJS, ArcElement, Tooltip, Legend, TooltipItem } from 'chart.js';
+import React, { useMemo } from 'react';
+import { Doughnut } from 'react-chartjs-2';
+
+ChartJS.register(ArcElement, Tooltip, Legend);
+
+export const MATCHUP_A_COLOR = '#3182ce';
+export const MATCHUP_B_COLOR = '#dd6b20';
+export const MATCHUP_NEITHER_COLOR = '#a0aec0';
+
+interface MatchupSplitDoughnutProps {
+  aName: string;
+  bName: string;
+  aWins: number;
+  bWins: number;
+  neitherCount: number;
+}
+
+export function MatchupSplitDoughnut({
+  aName,
+  bName,
+  aWins,
+  bWins,
+  neitherCount,
+}: MatchupSplitDoughnutProps): React.JSX.Element {
+  const total = aWins + bWins + neitherCount;
+
+  const data = useMemo(
+    () => ({
+      labels: [`${aName} won`, `${bName} won`, 'Neither'],
+      datasets: [
+        {
+          data: [aWins, bWins, neitherCount],
+          backgroundColor: [MATCHUP_A_COLOR, MATCHUP_B_COLOR, MATCHUP_NEITHER_COLOR],
+          borderColor: 'transparent',
+          borderWidth: 0,
+        },
+      ],
+    }),
+    [aName, bName, aWins, bWins, neitherCount],
+  );
+
+  const options = useMemo(
+    () => ({
+      responsive: true,
+      maintainAspectRatio: false,
+      cutout: '62%',
+      plugins: {
+        legend: {
+          position: 'bottom' as const,
+        },
+        tooltip: {
+          itemSort: (a: TooltipItem<'doughnut'>, b: TooltipItem<'doughnut'>): number =>
+            b.parsed - a.parsed,
+          callbacks: {
+            label: (context: TooltipItem<'doughnut'>): string => {
+              const value = context.parsed;
+              const pct = total > 0 ? ((value / total) * 100).toFixed(2) : '0.00';
+              return ` ${value} (${pct}%)`;
+            },
+          },
+        },
+      },
+    }),
+    [total],
+  );
+
+  return (
+    <Card.Root boxShadow="md">
+      <Card.Body p={2}>
+        <Box w="full" h={{ base: '240px', md: '280px' }}>
+          {/* @ts-ignore */}
+          <Doughnut data={data} options={options} />
+        </Box>
+      </Card.Body>
+    </Card.Root>
+  );
+}

--- a/src/app/components/charts/MatchupTrendChart.tsx
+++ b/src/app/components/charts/MatchupTrendChart.tsx
@@ -1,0 +1,126 @@
+import { Box, Card } from '@chakra-ui/react';
+import {
+  Chart as ChartJS,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+  Filler,
+  TooltipItem,
+} from 'chart.js';
+import annotationPlugin from 'chartjs-plugin-annotation';
+import React, { useMemo } from 'react';
+import { Line } from 'react-chartjs-2';
+
+import { downsampleForChart } from '../../backtest/runBacktest';
+import { cumulativeNetDiff, type MatchupEncounter } from '../../matchup/pirateMatchups';
+
+import { MATCHUP_A_COLOR } from './MatchupSplitDoughnut';
+
+ChartJS.register(LinearScale, PointElement, LineElement, Tooltip, Legend, Filler, annotationPlugin);
+
+interface MatchupTrendChartProps {
+  aName: string;
+  bName: string;
+  encounters: MatchupEncounter[];
+}
+
+/**
+ * Plots the running net win differential (A wins minus B wins, 'neither' rounds
+ * ignored) across the pair's shared-arena history. A rising line means A is
+ * pulling ahead; a falling line means B. The dashed zero line marks parity.
+ */
+export function MatchupTrendChart({
+  aName,
+  bName,
+  encounters,
+}: MatchupTrendChartProps): React.JSX.Element {
+  const rounds = useMemo(() => encounters.map(e => e.round), [encounters]);
+
+  const diffSeries = useMemo(() => cumulativeNetDiff(encounters), [encounters]);
+
+  const chartPoints = useMemo(() => downsampleForChart(diffSeries, rounds), [diffSeries, rounds]);
+
+  const data = useMemo(
+    () => ({
+      datasets: [
+        {
+          label: `${aName} \u2212 ${bName}`,
+          data: chartPoints,
+          borderColor: MATCHUP_A_COLOR,
+          backgroundColor: 'rgba(49, 130, 206, 0.10)',
+          pointRadius: encounters.length > 200 ? 0 : 2,
+          borderWidth: 1.5,
+          fill: 'origin',
+        },
+      ],
+    }),
+    [aName, bName, chartPoints, encounters.length],
+  );
+
+  const options = useMemo(
+    () => ({
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { display: false },
+        annotation: {
+          annotations: {
+            parityLine: {
+              type: 'line' as const,
+              yMin: 0,
+              yMax: 0,
+              borderColor: '#a0aec0',
+              borderWidth: 1,
+              borderDash: [4, 4],
+              label: {
+                display: true,
+                content: 'parity',
+                position: 'end' as const,
+              },
+            },
+          },
+        },
+        tooltip: {
+          displayColors: false,
+          callbacks: {
+            title: (items: TooltipItem<'line'>[]): string => {
+              const round = items[0]?.parsed.x;
+              return round !== undefined ? `Round ${round}` : '';
+            },
+            label: (context: TooltipItem<'line'>): string[] => {
+              const diff = context.parsed.y ?? 0;
+              const leader = diff === 0 ? 'tied' : diff > 0 ? aName : bName;
+              return [`${diff >= 0 ? '+' : ''}${diff} (${leader})`];
+            },
+          },
+        },
+      },
+      interaction: { mode: 'index' as const, intersect: false },
+      animation: { duration: 0 },
+      scales: {
+        x: {
+          type: 'linear' as const,
+          title: { display: true, text: 'Round' },
+        },
+        y: {
+          title: { display: true, text: `${aName} wins \u2212 ${bName} wins` },
+          ticks: { precision: 0 },
+        },
+      },
+    }),
+    [aName, bName],
+  );
+
+  return (
+    <Card.Root boxShadow="md">
+      <Card.Body p={2}>
+        <Box w="full" h={{ base: '240px', md: '320px' }}>
+          {/* @ts-ignore */}
+          <Line data={data} options={options} />
+        </Box>
+      </Card.Body>
+    </Card.Root>
+  );
+}

--- a/src/app/components/dev/DevModeDrawer.tsx
+++ b/src/app/components/dev/DevModeDrawer.tsx
@@ -1,12 +1,13 @@
 import { Button, Drawer, Portal, Stack, CloseButton, Separator } from '@chakra-ui/react';
 import * as React from 'react';
-import { FaBalanceScale, FaCode, FaStopwatch, FaTable } from 'react-icons/fa';
+import { FaBalanceScale, FaCode, FaCrosshairs, FaStopwatch, FaTable } from 'react-icons/fa';
 import { FaMagnifyingGlassChart } from 'react-icons/fa6';
 
 import { useDisclosureState } from '../../hooks/useDisclosureState';
 import { getReactScanEnabled, setReactScanEnabled } from '../../util/reactScan';
 import { AllBetsModal } from '../modals/AllBetsModal';
 import { BacktestComparisonModal } from '../modals/BacktestComparisonModal';
+import { PirateMatchupModal } from '../modals/PirateMatchupModal';
 import { RoundEndDriftModal } from '../modals/RoundEndDriftModal';
 import { RoundJsonModal } from '../modals/RoundJsonModal';
 import SettingsSwitch from '../TableSettings/SettingsSwitch';
@@ -21,6 +22,7 @@ export const DevModeDrawer: React.FC<DevModeDrawerProps> = ({ isOpen, onClose })
   const allBetsModal = useDisclosureState(false);
   const backtestModal = useDisclosureState(false);
   const driftModal = useDisclosureState(false);
+  const matchupModal = useDisclosureState(false);
   const [isReactScanEnabled, setIsReactScanEnabled] = React.useState(getReactScanEnabled);
 
   const handleReactScanToggle = React.useCallback((): void => {
@@ -75,6 +77,10 @@ export const DevModeDrawer: React.FC<DevModeDrawerProps> = ({ isOpen, onClose })
                     <FaStopwatch />
                     Round End-Time Drift
                   </Button>
+                  <Button width="full" onClick={matchupModal.onOpen}>
+                    <FaCrosshairs />
+                    Pirate Matchups (Head-to-Head)
+                  </Button>
                 </Stack>
               </Drawer.Body>
               <Drawer.Footer>
@@ -91,6 +97,7 @@ export const DevModeDrawer: React.FC<DevModeDrawerProps> = ({ isOpen, onClose })
       <AllBetsModal isOpen={allBetsModal.isOpen} onClose={allBetsModal.onClose} />
       <BacktestComparisonModal isOpen={backtestModal.isOpen} onClose={backtestModal.onClose} />
       <RoundEndDriftModal isOpen={driftModal.isOpen} onClose={driftModal.onClose} />
+      <PirateMatchupModal isOpen={matchupModal.isOpen} onClose={matchupModal.onClose} />
     </>
   );
 };

--- a/src/app/components/modals/PirateMatchupModal.tsx
+++ b/src/app/components/modals/PirateMatchupModal.tsx
@@ -35,6 +35,8 @@ import {
 } from '../charts/MatchupSplitDoughnut';
 import { MatchupTrendChart } from '../charts/MatchupTrendChart';
 
+import { Tooltip } from '@/components/ui/tooltip';
+
 interface PirateMatchupModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -61,10 +63,6 @@ function pirateFullName(id: number): string {
 
 function displayPercent(value: number): string {
   return `${(value * 100).toFixed(2)}%`;
-}
-
-function streakText(side: string, count: number): string {
-  return `${side} won ${count} in a row`;
 }
 
 function PirateColumn({
@@ -421,14 +419,16 @@ export function PirateMatchupModal({
                           <HStack gap={4} flexWrap="wrap">
                             {aLongest && (
                               <Text fontSize="xs" color="fg.muted">
-                                Longest {aName} run: <b>{streakText(aName, aLongest.count)}</b>{' '}
-                                (rounds {aLongest.startRound}&ndash;{aLongest.endRound})
+                                Longest {aName} streak:{' '}
+                                <b>{aLongest.count} shared arenas won in a row</b> (rounds{' '}
+                                {aLongest.startRound}&ndash;{aLongest.endRound})
                               </Text>
                             )}
                             {bLongest && (
                               <Text fontSize="xs" color="fg.muted">
-                                Longest {bName} run: <b>{streakText(bName, bLongest.count)}</b>{' '}
-                                (rounds {bLongest.startRound}&ndash;{bLongest.endRound})
+                                Longest {bName} streak:{' '}
+                                <b>{bLongest.count} shared arenas won in a row</b> (rounds{' '}
+                                {bLongest.startRound}&ndash;{bLongest.endRound})
                               </Text>
                             )}
                           </HStack>
@@ -439,26 +439,29 @@ export function PirateMatchupModal({
                             </Text>
                             <HStack gap={1}>
                               {recentForm.map(encounter => (
-                                <Box
+                                <Tooltip
                                   key={`${encounter.round}-${encounter.arena}`}
-                                  w="10px"
-                                  h="10px"
-                                  borderRadius="2px"
-                                  bg={
-                                    encounter.outcome === 'a'
-                                      ? MATCHUP_A_COLOR
-                                      : encounter.outcome === 'b'
-                                        ? MATCHUP_B_COLOR
-                                        : MATCHUP_NEITHER_COLOR
-                                  }
-                                  title={`Round ${encounter.round} (${ARENA_NAMES[encounter.arena]}): ${
+                                  content={`Round ${encounter.round} (${ARENA_NAMES[encounter.arena]}): ${
                                     encounter.outcome === 'a'
                                       ? `${aName} won`
                                       : encounter.outcome === 'b'
                                         ? `${bName} won`
                                         : 'neither won'
                                   }`}
-                                />
+                                >
+                                  <Box
+                                    w="10px"
+                                    h="10px"
+                                    borderRadius="2px"
+                                    bg={
+                                      encounter.outcome === 'a'
+                                        ? MATCHUP_A_COLOR
+                                        : encounter.outcome === 'b'
+                                          ? MATCHUP_B_COLOR
+                                          : MATCHUP_NEITHER_COLOR
+                                    }
+                                  />
+                                </Tooltip>
                               ))}
                             </HStack>
                             {(aCurrent || bCurrent) && (

--- a/src/app/components/modals/PirateMatchupModal.tsx
+++ b/src/app/components/modals/PirateMatchupModal.tsx
@@ -1,0 +1,508 @@
+import {
+  Box,
+  Button,
+  Card,
+  CloseButton,
+  Code,
+  Dialog,
+  HStack,
+  Input,
+  Portal,
+  Select,
+  SimpleGrid,
+  Stack,
+  Text,
+  createListCollection,
+} from '@chakra-ui/react';
+import * as React from 'react';
+import { FaExchangeAlt } from 'react-icons/fa';
+
+import { ARENA_NAMES, PIRATE_NAMES, FULL_PIRATE_NAMES } from '../../constants';
+import { useBacktestPreviousRounds } from '../../hooks/useBacktestPreviousRounds';
+import {
+  arenaBreakdown,
+  currentStreak,
+  findSharedEncounters,
+  longestWinStreak,
+  summarizeMatchup,
+} from '../../matchup/pirateMatchups';
+import { MatchupArenaBarChart } from '../charts/MatchupArenaBarChart';
+import {
+  MATCHUP_A_COLOR,
+  MATCHUP_B_COLOR,
+  MATCHUP_NEITHER_COLOR,
+  MatchupSplitDoughnut,
+} from '../charts/MatchupSplitDoughnut';
+import { MatchupTrendChart } from '../charts/MatchupTrendChart';
+
+interface PirateMatchupModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+type RangePreset = 'last30' | 'last100' | 'last500' | 'all';
+
+const RANGE_PRESETS: { value: RangePreset; label: string; count: number | null }[] = [
+  { value: 'last30', label: 'Last 30', count: 30 },
+  { value: 'last100', label: 'Last 100', count: 100 },
+  { value: 'last500', label: 'Last 500', count: 500 },
+  { value: 'all', label: 'All time', count: null },
+];
+
+const RECENT_FORM_COUNT = 25;
+
+function pirateName(id: number): string {
+  return PIRATE_NAMES.get(id) ?? `Pirate ${id}`;
+}
+
+function pirateFullName(id: number): string {
+  return FULL_PIRATE_NAMES.get(id) ?? `Pirate ${id}`;
+}
+
+function displayPercent(value: number): string {
+  return `${(value * 100).toFixed(2)}%`;
+}
+
+function streakText(side: string, count: number): string {
+  return `${side} won ${count} in a row`;
+}
+
+function PirateColumn({
+  label,
+  value,
+  otherValue,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  otherValue: number;
+  onChange: (id: number) => void;
+}): React.JSX.Element {
+  const collection = React.useMemo(
+    () =>
+      createListCollection({
+        items: Array.from(PIRATE_NAMES, ([id, name]) => ({
+          label: name,
+          value: String(id),
+        })),
+      }),
+    [],
+  );
+
+  return (
+    <Stack gap={1}>
+      <Text fontSize="xs" color="fg.muted">
+        {label}
+      </Text>
+      <Select.Root
+        collection={collection}
+        size="sm"
+        value={[String(value)]}
+        minW="140px"
+        onValueChange={(details: { value: string[] }) => {
+          const id = parseInt(details.value[0] ?? '', 10);
+          if (!Number.isNaN(id) && id !== otherValue) {
+            onChange(id);
+          }
+        }}
+      >
+        <Select.HiddenSelect />
+        <Select.Control layerStyle="fill.subtle">
+          <Select.Trigger>
+            <Select.ValueText />
+          </Select.Trigger>
+          <Select.IndicatorGroup>
+            <Select.Indicator />
+          </Select.IndicatorGroup>
+        </Select.Control>
+        <Select.Positioner>
+          <Select.Content>
+            {collection.items.map(item => (
+              <Select.Item
+                item={item}
+                key={item.value}
+                {...(Number(item.value) === otherValue
+                  ? { _disabled: { opacity: 0.5, cursor: 'not-allowed' } }
+                  : {})}
+              >
+                <Select.ItemText>{item.label}</Select.ItemText>
+              </Select.Item>
+            ))}
+          </Select.Content>
+        </Select.Positioner>
+      </Select.Root>
+    </Stack>
+  );
+}
+
+export function PirateMatchupModal({
+  isOpen,
+  onClose,
+}: PirateMatchupModalProps): React.JSX.Element {
+  const { status, rounds, newestRound, error, refetch } = useBacktestPreviousRounds({
+    enabled: isOpen,
+  });
+
+  // Defaults mirror the classic Gooblah-vs-Buck rivalry so something interesting
+  // is on screen as soon as history has loaded.
+  const [pirateAId, setPirateAId] = React.useState(15);
+  const [pirateBId, setPirateBId] = React.useState(19);
+  const [rangePreset, setRangePreset] = React.useState<RangePreset>('all');
+  const [minRoundInput, setMinRoundInput] = React.useState('');
+  const [maxRoundInput, setMaxRoundInput] = React.useState('');
+
+  const aName = pirateName(pirateAId);
+  const bName = pirateName(pirateBId);
+
+  const allEncounters = React.useMemo(
+    () => (status === 'ready' ? findSharedEncounters(rounds, pirateAId, pirateBId) : []),
+    [status, rounds, pirateAId, pirateBId],
+  );
+
+  const visibleEncounters = React.useMemo(() => {
+    if (allEncounters.length === 0) {
+      return [];
+    }
+
+    const min = parseInt(minRoundInput, 10);
+    const max = parseInt(maxRoundInput, 10);
+    const hasCustomRange = !Number.isNaN(min) || !Number.isNaN(max);
+
+    let filtered = allEncounters;
+    if (hasCustomRange) {
+      filtered = filtered.filter(encounter => {
+        const aboveMin = Number.isNaN(min) || encounter.round >= min;
+        const belowMax = Number.isNaN(max) || encounter.round <= max;
+        return aboveMin && belowMax;
+      });
+    } else {
+      const preset = RANGE_PRESETS.find(p => p.value === rangePreset);
+      if (preset && preset.count !== null) {
+        filtered = filtered.slice(-preset.count);
+      }
+    }
+
+    return filtered;
+  }, [allEncounters, rangePreset, minRoundInput, maxRoundInput]);
+
+  const summary = React.useMemo(() => summarizeMatchup(visibleEncounters), [visibleEncounters]);
+  const breakdown = React.useMemo(() => arenaBreakdown(visibleEncounters), [visibleEncounters]);
+
+  const aLongest = React.useMemo(
+    () => longestWinStreak(visibleEncounters, 'a'),
+    [visibleEncounters],
+  );
+  const bLongest = React.useMemo(
+    () => longestWinStreak(visibleEncounters, 'b'),
+    [visibleEncounters],
+  );
+  const aCurrent = React.useMemo(() => currentStreak(visibleEncounters, 'a'), [visibleEncounters]);
+  const bCurrent = React.useMemo(() => currentStreak(visibleEncounters, 'b'), [visibleEncounters]);
+
+  const statusText = React.useMemo(() => {
+    if (status === 'loading') {
+      return 'Downloading previous.jsonl (~13MB)...';
+    }
+    if (status === 'error') {
+      return error ?? 'Failed to load round history.';
+    }
+    if (status === 'ready') {
+      return `${rounds.length} rounds loaded (newest #${newestRound}).`;
+    }
+    return '';
+  }, [status, error, rounds.length, newestRound]);
+
+  const handlePresetClick = React.useCallback((preset: RangePreset): void => {
+    setRangePreset(preset);
+    // A preset supersedes any custom bounds.
+    setMinRoundInput('');
+    setMaxRoundInput('');
+  }, []);
+
+  const handleSwap = React.useCallback((): void => {
+    setPirateAId(pirateBId);
+    setPirateBId(pirateAId);
+  }, [pirateAId, pirateBId]);
+
+  const decided = summary.aWins + summary.bWins;
+  const recentForm = visibleEncounters.slice(-RECENT_FORM_COUNT);
+
+  return (
+    <Dialog.Root
+      open={isOpen}
+      onOpenChange={(e: { open: boolean }) => !e.open && onClose()}
+      size="cover"
+      preventScroll
+      modal
+    >
+      <Portal>
+        <Dialog.Backdrop />
+        <Dialog.Positioner>
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>Pirate Matchups</Dialog.Title>
+              <Dialog.CloseTrigger asChild>
+                <CloseButton size="sm" />
+              </Dialog.CloseTrigger>
+            </Dialog.Header>
+            <Dialog.Body display="flex" flexDirection="column" overflowY="auto">
+              <Stack gap={4}>
+                <Text fontSize="sm" color="fg.muted">
+                  Every round all 20 pirates are fielded - four per arena, reshuffled daily. Pick
+                  two pirates to see how they do <em>when drawn into the same arena</em>: who takes
+                  their head-to-head, where it happens, and how the rivalry has trended over time.
+                </Text>
+
+                <HStack justify="space-between" flexWrap="wrap" gap={2}>
+                  <Text fontSize="sm" color="fg.muted">
+                    {statusText}
+                  </Text>
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    onClick={() => refetch()}
+                    disabled={status === 'loading'}
+                  >
+                    Refresh
+                  </Button>
+                </HStack>
+
+                <Card.Root boxShadow="sm">
+                  <Card.Body p={3}>
+                    <Stack gap={3} direction={{ base: 'column', md: 'row' }} align="center">
+                      <HStack gap={3} flexWrap="wrap" justify="center">
+                        <PirateColumn
+                          label="Pirate A"
+                          value={pirateAId}
+                          otherValue={pirateBId}
+                          onChange={setPirateAId}
+                        />
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={handleSwap}
+                          title="Swap A and B"
+                          aria-label="Swap pirates"
+                        >
+                          <FaExchangeAlt />
+                        </Button>
+                        <PirateColumn
+                          label="Pirate B"
+                          value={pirateBId}
+                          otherValue={pirateAId}
+                          onChange={setPirateBId}
+                        />
+                      </HStack>
+
+                      <HStack gap={2} flexWrap="wrap" justify="center">
+                        {RANGE_PRESETS.map(preset => (
+                          <Button
+                            key={preset.value}
+                            size="xs"
+                            variant={
+                              rangePreset === preset.value && !minRoundInput && !maxRoundInput
+                                ? 'solid'
+                                : 'outline'
+                            }
+                            onClick={() => handlePresetClick(preset.value)}
+                          >
+                            {preset.label}
+                          </Button>
+                        ))}
+                      </HStack>
+
+                      <HStack gap={2} justify="center">
+                        <Input
+                          type="number"
+                          placeholder="Min round"
+                          value={minRoundInput}
+                          onChange={e => setMinRoundInput(e.target.value)}
+                          width="110px"
+                          size="xs"
+                        />
+                        <Text fontSize="sm" color="fg.muted">
+                          to
+                        </Text>
+                        <Input
+                          type="number"
+                          placeholder="Max round"
+                          value={maxRoundInput}
+                          onChange={e => setMaxRoundInput(e.target.value)}
+                          width="110px"
+                          size="xs"
+                        />
+                      </HStack>
+                    </Stack>
+                  </Card.Body>
+                </Card.Root>
+
+                {status === 'ready' && visibleEncounters.length === 0 && (
+                  <Text fontSize="sm" color="fg.muted">
+                    {aName} and {bName} never shared an arena in the selected range.
+                  </Text>
+                )}
+
+                {visibleEncounters.length > 0 && (
+                  <>
+                    <Card.Root boxShadow="sm">
+                      <Card.Body p={3}>
+                        <Stack gap={3}>
+                          {/* The neobot-style summary, with the numbers the sentence is about. */}
+                          <Text fontSize="sm" lineHeight="tall">
+                            {aName} and {bName} played the same arena{' '}
+                            <Code fontSize="sm">{summary.sharedRounds}</Code> times - {aName} won{' '}
+                            <Box as="span" color={MATCHUP_A_COLOR} fontWeight="semibold">
+                              {summary.aWins} (
+                              {displayPercent(
+                                summary.sharedRounds > 0 ? summary.aWins / summary.sharedRounds : 0,
+                              )}
+                              )
+                            </Box>
+                            , {bName} won{' '}
+                            <Box as="span" color={MATCHUP_B_COLOR} fontWeight="semibold">
+                              {summary.bWins} (
+                              {displayPercent(
+                                summary.sharedRounds > 0 ? summary.bWins / summary.sharedRounds : 0,
+                              )}
+                              )
+                            </Box>
+                            , and neither of them won{' '}
+                            <Code fontSize="sm">
+                              {summary.neitherCount} (
+                              {displayPercent(
+                                summary.sharedRounds > 0
+                                  ? summary.neitherCount / summary.sharedRounds
+                                  : 0,
+                              )}
+                              )
+                            </Code>
+                            .
+                          </Text>
+
+                          {/* Head-to-head among *decided* arenas - the fair fight metric. */}
+                          {summary.headToHeadA !== null && summary.headToHeadB !== null ? (
+                            <Stack gap={1}>
+                              <HStack justify="space-between">
+                                <Text fontSize="xs" color="fg.muted">
+                                  Head-to-head (decided arenas only, n={decided})
+                                </Text>
+                              </HStack>
+                              <Box h="24px" borderRadius="md" overflow="hidden" display="flex">
+                                <Box
+                                  bg={MATCHUP_A_COLOR}
+                                  flexBasis={`${summary.headToHeadA * 100}%`}
+                                  display="flex"
+                                  alignItems="center"
+                                  justifyContent="center"
+                                >
+                                  <Text fontSize="xs" color="white" fontWeight="semibold">
+                                    {aName} {displayPercent(summary.headToHeadA)}
+                                  </Text>
+                                </Box>
+                                <Box
+                                  bg={MATCHUP_B_COLOR}
+                                  flexBasis={`${summary.headToHeadB * 100}%`}
+                                  display="flex"
+                                  alignItems="center"
+                                  justifyContent="center"
+                                >
+                                  <Text fontSize="xs" color="white" fontWeight="semibold">
+                                    {bName} {displayPercent(summary.headToHeadB)}
+                                  </Text>
+                                </Box>
+                              </Box>
+                            </Stack>
+                          ) : (
+                            <Text fontSize="xs" color="fg.muted">
+                              Neither pirate ever won their head-to-head in this range.
+                            </Text>
+                          )}
+
+                          <HStack gap={4} flexWrap="wrap">
+                            {aLongest && (
+                              <Text fontSize="xs" color="fg.muted">
+                                Longest {aName} run: <b>{streakText(aName, aLongest.count)}</b>{' '}
+                                (rounds {aLongest.startRound}&ndash;{aLongest.endRound})
+                              </Text>
+                            )}
+                            {bLongest && (
+                              <Text fontSize="xs" color="fg.muted">
+                                Longest {bName} run: <b>{streakText(bName, bLongest.count)}</b>{' '}
+                                (rounds {bLongest.startRound}&ndash;{bLongest.endRound})
+                              </Text>
+                            )}
+                          </HStack>
+
+                          <HStack gap={2} align="center" flexWrap="wrap">
+                            <Text fontSize="xs" color="fg.muted">
+                              Last {recentForm.length} shared arenas:
+                            </Text>
+                            <HStack gap={1}>
+                              {recentForm.map(encounter => (
+                                <Box
+                                  key={`${encounter.round}-${encounter.arena}`}
+                                  w="10px"
+                                  h="10px"
+                                  borderRadius="2px"
+                                  bg={
+                                    encounter.outcome === 'a'
+                                      ? MATCHUP_A_COLOR
+                                      : encounter.outcome === 'b'
+                                        ? MATCHUP_B_COLOR
+                                        : MATCHUP_NEITHER_COLOR
+                                  }
+                                  title={`Round ${encounter.round} (${ARENA_NAMES[encounter.arena]}): ${
+                                    encounter.outcome === 'a'
+                                      ? `${aName} won`
+                                      : encounter.outcome === 'b'
+                                        ? `${bName} won`
+                                        : 'neither won'
+                                  }`}
+                                />
+                              ))}
+                            </HStack>
+                            {(aCurrent || bCurrent) && (
+                              <Text fontSize="xs" color="fg.muted">
+                                {aCurrent
+                                  ? `${aName} is on a ${aCurrent.count}-arena win streak`
+                                  : `${bName} is on a ${bCurrent!.count}-arena win streak`}
+                              </Text>
+                            )}
+                          </HStack>
+                        </Stack>
+                      </Card.Body>
+                    </Card.Root>
+
+                    <SimpleGrid columns={{ base: 1, md: 2 }} gap={3}>
+                      <MatchupSplitDoughnut
+                        aName={aName}
+                        bName={bName}
+                        aWins={summary.aWins}
+                        bWins={summary.bWins}
+                        neitherCount={summary.neitherCount}
+                      />
+                      <MatchupArenaBarChart aName={aName} bName={bName} breakdown={breakdown} />
+                    </SimpleGrid>
+
+                    <MatchupTrendChart aName={aName} bName={bName} encounters={visibleEncounters} />
+
+                    <Text fontSize="xs" color="fg.muted">
+                      {pirateFullName(pirateAId)} vs. {pirateFullName(pirateBId)}. Shared-arena
+                      counts include every completed round in the selected range;
+                      &quot;neither&quot; means one of the other two pirates in that arena took it.
+                    </Text>
+                  </>
+                )}
+              </Stack>
+            </Dialog.Body>
+            <Dialog.Footer>
+              <Button variant="outline" onClick={onClose}>
+                Close
+              </Button>
+            </Dialog.Footer>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/app/matchup/__tests__/pirateMatchups.test.ts
+++ b/src/app/matchup/__tests__/pirateMatchups.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from 'vitest';
+
+import type { BacktestRound } from '../../backtest/types';
+import {
+  arenaBreakdown,
+  cumulativeNetDiff,
+  currentStreak,
+  findSharedEncounters,
+  longestWinStreak,
+  summarizeMatchup,
+} from '../pirateMatchups';
+
+// Gooblah and Buck for all test cases below.
+const A_ID = 15;
+const B_ID = 19;
+
+function makeRound(round: number, arenas: (number[] | null)[], winners: number[]): BacktestRound {
+  const pirates = arenas.map(arena => arena ?? [0, 0, 0, 0]);
+  const odds = (v: number): number[] => [1, v, v + 1, v + 2];
+  return {
+    round,
+    pirates: pirates as number[][],
+    openingOdds: [1, 2, 3, 4, 5].map(odds),
+    currentOdds: [1, 2, 3, 4, 5].map(odds),
+    winners,
+  };
+}
+
+/** A full, valid 20-pirate roster with Gooblah(15) and Buck(19) in `arena` at the given slots. */
+function rosterWithPair(arena: number, aSlot: number, bSlot: number): number[][] {
+  const others = Array.from({ length: 20 }, (_, i) => i + 1).filter(
+    id => id !== A_ID && id !== B_ID,
+  );
+  const arenas: (number | undefined)[][] = Array.from({ length: 5 }, () => [
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+  ]);
+
+  arenas[arena]![aSlot] = A_ID;
+  arenas[arena]![bSlot] = B_ID;
+
+  let nextPirate = 0;
+  for (let a = 0; a < 5; a++) {
+    for (let slot = 0; slot < 4; slot++) {
+      if (arenas[a]![slot] === undefined) {
+        arenas[a]![slot] = others[nextPirate++]!;
+      }
+    }
+  }
+
+  return arenas as number[][];
+}
+
+describe('findSharedEncounters', () => {
+  it('records one encounter per round in which both pirates share an arena', () => {
+    const rounds: BacktestRound[] = [
+      // Round 100: both in arena 0, slot 1/2 -> Gooblah wins (winner slot 1).
+      makeRound(100, rosterWithPair(0, 0, 1), [1, 2, 3, 4, 5]),
+      // Round 101: both in arena 0, Buck first -> winner slot 2 is Gooblah? No:
+      // roster [15,19,...] with winner slot 2 -> index 1 = Buck wins.
+      makeRound(101, rosterWithPair(0, 0, 1), [2, 2, 3, 4, 5]),
+      // Round 102: both in arena 0, third pirate wins (winner slot 3).
+      makeRound(102, rosterWithPair(0, 0, 1), [3, 2, 3, 4, 5]),
+      // Round 103: both in arena 2, Gooblah first (winner slot 1).
+      makeRound(103, rosterWithPair(2, 0, 1), [2, 2, 1, 4, 5]),
+      // Round 104: pirates split across arenas -> no encounter.
+      makeRound(
+        104,
+        [
+          [15, 2, 3, 4],
+          [19, 5, 6, 7],
+          [8, 9, 10, 11],
+          [12, 13, 14, 16],
+          [17, 18, 20, 1],
+        ] as (number[] | null)[],
+        [2, 3, 4, 5, 1],
+      ),
+      // Round 105: both in arena 4, Buck at slot 2 (winner slot 2).
+      makeRound(
+        105,
+        [
+          [4, 5, 6, 7],
+          [1, 2, 3, 8],
+          [9, 10, 11, 12],
+          [13, 14, 16, 17],
+          [20, 19, 15, 18],
+        ] as (number[] | null)[],
+        [2, 3, 4, 5, 2],
+      ),
+      // Round with null winners (filtered upstream by fetchPreviousRounds) must be ignored.
+      {
+        ...makeRound(106, rosterWithPair(0, 0, 1), [2, 3, 4, 5, 1]),
+        winners: null as unknown as number[],
+      },
+    ];
+
+    const encounters = findSharedEncounters(rounds, A_ID, B_ID);
+
+    expect(encounters).toEqual([
+      { round: 100, arena: 0, outcome: 'a' },
+      { round: 101, arena: 0, outcome: 'b' },
+      { round: 102, arena: 0, outcome: 'neither' },
+      { round: 103, arena: 2, outcome: 'a' },
+      { round: 105, arena: 4, outcome: 'b' },
+    ]);
+  });
+
+  it('returns an empty list when the pirates never share an arena', () => {
+    const rounds: BacktestRound[] = [
+      makeRound(
+        1,
+        [
+          [15, 2, 3, 4],
+          [19, 5, 6, 7],
+          [8, 9, 10, 11],
+          [12, 13, 14, 16],
+          [17, 18, 20, 1],
+        ] as (number[] | null)[],
+        [1, 2, 3, 4, 5],
+      ),
+    ];
+
+    expect(findSharedEncounters(rounds, A_ID, B_ID)).toEqual([]);
+  });
+
+  it('is symmetric with respect to the two pirates (swapping sides flips a/b outcomes)', () => {
+    // Roster [B, x, A, x] in arena 3 with winner slot 1 -> B wins for the (A,B) ordering.
+    const rounds: BacktestRound[] = [makeRound(1, rosterWithPair(3, 2, 0), [4, 2, 3, 1, 5])];
+    expect(findSharedEncounters(rounds, A_ID, B_ID)).toEqual([
+      { round: 1, arena: 3, outcome: 'b' },
+    ]);
+    const ab = findSharedEncounters(rounds, A_ID, B_ID);
+    const ba = findSharedEncounters(rounds, B_ID, A_ID).map(e => ({
+      ...e,
+      outcome: e.outcome === 'a' ? ('b' as const) : e.outcome === 'b' ? ('a' as const) : e.outcome,
+    }));
+
+    expect(ab).toEqual(ba);
+  });
+});
+
+describe('summarizeMatchup', () => {
+  it('aggregates wins, losses and neither outcomes with head-to-head rates', () => {
+    const encounters = [
+      { round: 1, arena: 0, outcome: 'a' as const },
+      { round: 2, arena: 0, outcome: 'a' as const },
+      { round: 3, arena: 1, outcome: 'b' as const },
+      { round: 4, arena: 0, outcome: 'neither' as const },
+    ];
+
+    expect(summarizeMatchup(encounters)).toEqual({
+      sharedRounds: 4,
+      aWins: 2,
+      bWins: 1,
+      neitherCount: 1,
+      headToHeadA: 2 / 3,
+      headToHeadB: 1 / 3,
+    });
+  });
+
+  it('returns null head-to-head rates when nothing was decided', () => {
+    const encounters = [
+      { round: 1, arena: 0, outcome: 'neither' as const },
+      { round: 2, arena: 0, outcome: 'neither' as const },
+    ];
+
+    expect(summarizeMatchup(encounters)).toEqual({
+      sharedRounds: 2,
+      aWins: 0,
+      bWins: 0,
+      neitherCount: 2,
+      headToHeadA: null,
+      headToHeadB: null,
+    });
+  });
+
+  it('handles an empty encounter list', () => {
+    expect(summarizeMatchup([])).toEqual({
+      sharedRounds: 0,
+      aWins: 0,
+      bWins: 0,
+      neitherCount: 0,
+      headToHeadA: null,
+      headToHeadB: null,
+    });
+  });
+});
+
+describe('arenaBreakdown', () => {
+  it('splits encounters by arena and keeps zero rows for unused arenas', () => {
+    const encounters = [
+      { round: 1, arena: 0, outcome: 'a' as const },
+      { round: 2, arena: 0, outcome: 'b' as const },
+      { round: 3, arena: 0, outcome: 'neither' as const },
+      { round: 4, arena: 2, outcome: 'a' as const },
+      { round: 5, arena: 4, outcome: 'b' as const },
+    ];
+
+    expect(arenaBreakdown(encounters)).toEqual([
+      { arena: 0, sharedCount: 3, aWins: 1, bWins: 1, neitherCount: 1 },
+      { arena: 1, sharedCount: 0, aWins: 0, bWins: 0, neitherCount: 0 },
+      { arena: 2, sharedCount: 1, aWins: 1, bWins: 0, neitherCount: 0 },
+      { arena: 3, sharedCount: 0, aWins: 0, bWins: 0, neitherCount: 0 },
+      { arena: 4, sharedCount: 1, aWins: 0, bWins: 1, neitherCount: 0 },
+    ]);
+  });
+});
+
+describe('streaks', () => {
+  const encounters = [
+    { round: 100, arena: 0, outcome: 'a' as const },
+    { round: 101, arena: 0, outcome: 'b' as const },
+    { round: 102, arena: 0, outcome: 'neither' as const },
+    { round: 103, arena: 2, outcome: 'a' as const },
+    { round: 105, arena: 4, outcome: 'b' as const },
+    { round: 106, arena: 0, outcome: 'a' as const },
+    { round: 107, arena: 1, outcome: 'a' as const },
+  ];
+
+  it('finds the longest win streak for each side', () => {
+    expect(longestWinStreak(encounters, 'a')).toEqual({ count: 2, startRound: 106, endRound: 107 });
+    expect(longestWinStreak(encounters, 'b')).toEqual({ count: 1, startRound: 101, endRound: 101 });
+    expect(longestWinStreak(encounters.slice(0, 3), 'a')).toEqual({
+      count: 1,
+      startRound: 100,
+      endRound: 100,
+    });
+  });
+
+  it('returns null when the side never won', () => {
+    expect(longestWinStreak(encounters.slice(1, 3), 'a')).toBeNull();
+    expect(longestWinStreak([], 'b')).toBeNull();
+  });
+
+  it('reports the streak at the end of the list, or null when not currently on one', () => {
+    expect(currentStreak(encounters, 'a')).toEqual({ count: 2, startRound: 106, endRound: 107 });
+    expect(currentStreak(encounters, 'b')).toBeNull();
+    // Entire list is one side's wins.
+    expect(currentStreak([encounters[0]!], 'a')).toEqual({
+      count: 1,
+      startRound: 100,
+      endRound: 100,
+    });
+    expect(currentStreak([], 'a')).toBeNull();
+  });
+});
+
+describe('cumulativeNetDiff', () => {
+  it('tracks the running net win differential, ignoring neither outcomes', () => {
+    const encounters = [
+      { round: 1, arena: 0, outcome: 'a' as const },
+      { round: 2, arena: 0, outcome: 'b' as const },
+      { round: 3, arena: 0, outcome: 'neither' as const },
+      { round: 4, arena: 0, outcome: 'a' as const },
+    ];
+
+    expect(cumulativeNetDiff(encounters)).toEqual([1, 0, 0, 1]);
+    expect(cumulativeNetDiff([])).toEqual([]);
+  });
+});

--- a/src/app/matchup/pirateMatchups.ts
+++ b/src/app/matchup/pirateMatchups.ts
@@ -1,0 +1,220 @@
+import type { BacktestRound } from '../backtest/types';
+
+/** Which side took a shared arena: `a`, `b`, or neither (the other two pirates won). */
+export type MatchupOutcome = 'a' | 'b' | 'neither';
+
+/** One round in which both pirates were placed in the same arena. */
+export interface MatchupEncounter {
+  round: number;
+  arena: number;
+  outcome: MatchupOutcome;
+}
+
+export interface ArenaMatchupBreakdown {
+  arena: number;
+  sharedCount: number;
+  aWins: number;
+  bWins: number;
+  neitherCount: number;
+}
+
+export interface MatchupSummary {
+  sharedRounds: number;
+  aWins: number;
+  bWins: number;
+  neitherCount: number;
+  /** A's share of *decided* encounters (aWins / (aWins + bWins)), null when undecided. */
+  headToHeadA: number | null;
+  /** B's share of *decided* encounters (bWins / (aWins + bWins)), null when undecided. */
+  headToHeadB: number | null;
+}
+
+export interface WinStreak {
+  count: number;
+  startRound: number;
+  endRound: number;
+}
+
+/**
+ * Scans every completed round and records each arena in which both pirates were
+ * placed together. Because all 20 pirates appear exactly once per round (one per
+ * arena slot), a pair can share at most one arena in any given round - so the
+ * encounter count equals "played the same arena N times".
+ */
+export function findSharedEncounters(
+  rounds: BacktestRound[],
+  aId: number,
+  bId: number,
+): MatchupEncounter[] {
+  const encounters: MatchupEncounter[] = [];
+
+  for (const round of rounds) {
+    const winners = round.winners;
+    if (!winners || winners.length !== 5) {
+      continue;
+    }
+
+    for (let arena = 0; arena < 5; arena++) {
+      const roster = round.pirates[arena];
+      if (!Array.isArray(roster)) {
+        continue;
+      }
+
+      const aSlot = roster.indexOf(aId);
+      if (aSlot === -1) {
+        continue;
+      }
+      const bSlot = roster.indexOf(bId);
+      if (bSlot === -1) {
+        continue;
+      }
+
+      const winnerSlot = winners[arena];
+      const winningId = winnerSlot !== undefined ? roster[winnerSlot - 1] : undefined;
+      let outcome: MatchupOutcome;
+      if (winningId === aId) {
+        outcome = 'a';
+      } else if (winningId === bId) {
+        outcome = 'b';
+      } else {
+        outcome = 'neither';
+      }
+
+      encounters.push({ round: round.round, arena, outcome });
+    }
+  }
+
+  return encounters;
+}
+
+/** Aggregates an encounter list into the headline "who won how often" numbers. */
+export function summarizeMatchup(encounters: MatchupEncounter[]): MatchupSummary {
+  let aWins = 0;
+  let bWins = 0;
+  let neitherCount = 0;
+
+  for (const encounter of encounters) {
+    if (encounter.outcome === 'a') {
+      aWins += 1;
+    } else if (encounter.outcome === 'b') {
+      bWins += 1;
+    } else {
+      neitherCount += 1;
+    }
+  }
+
+  const decided = aWins + bWins;
+  return {
+    sharedRounds: encounters.length,
+    aWins,
+    bWins,
+    neitherCount,
+    headToHeadA: decided > 0 ? aWins / decided : null,
+    headToHeadB: decided > 0 ? bWins / decided : null,
+  };
+}
+
+/** Per-arena totals, always in arena order 0-4 (arenas with no shared rounds are zeroed). */
+export function arenaBreakdown(encounters: MatchupEncounter[]): ArenaMatchupBreakdown[] {
+  const breakdown = Array.from({ length: 5 }, (_, arena) => ({
+    arena,
+    sharedCount: 0,
+    aWins: 0,
+    bWins: 0,
+    neitherCount: 0,
+  }));
+
+  for (const encounter of encounters) {
+    const row = breakdown[encounter.arena];
+    if (!row) {
+      continue;
+    }
+    row.sharedCount += 1;
+    if (encounter.outcome === 'a') {
+      row.aWins += 1;
+    } else if (encounter.outcome === 'b') {
+      row.bWins += 1;
+    } else {
+      row.neitherCount += 1;
+    }
+  }
+
+  return breakdown;
+}
+
+/** Longest run of consecutive encounters won by `outcome`, or null if never. */
+export function longestWinStreak(
+  encounters: MatchupEncounter[],
+  outcome: Exclude<MatchupOutcome, 'neither'>,
+): WinStreak | null {
+  let best: WinStreak | null = null;
+  let runStart = -1;
+
+  for (let i = 0; i < encounters.length; i++) {
+    const isWin = encounters[i]!.outcome === outcome;
+    if (isWin && runStart === -1) {
+      runStart = i;
+    } else if (!isWin && runStart !== -1) {
+      const count = i - runStart;
+      if (!best || count > best.count) {
+        best = {
+          count,
+          startRound: encounters[runStart]!.round,
+          endRound: encounters[i - 1]!.round,
+        };
+      }
+      runStart = -1;
+    }
+  }
+
+  if (runStart !== -1) {
+    const count = encounters.length - runStart;
+    if (!best || count > best.count) {
+      best = {
+        count,
+        startRound: encounters[runStart]!.round,
+        endRound: encounters[encounters.length - 1]!.round,
+      };
+    }
+  }
+
+  return best;
+}
+
+/** Consecutive wins by `outcome` at the *end* of the encounter list, or null if not on a streak. */
+export function currentStreak(
+  encounters: MatchupEncounter[],
+  outcome: Exclude<MatchupOutcome, 'neither'>,
+): WinStreak | null {
+  let i = encounters.length - 1;
+  while (i >= 0 && encounters[i]!.outcome === outcome) {
+    i -= 1;
+  }
+
+  if (i === encounters.length - 1) {
+    return null; // last encounter was not a win by this side (or no encounters)
+  }
+
+  return {
+    count: encounters.length - 1 - i,
+    startRound: encounters[i + 1]!.round,
+    endRound: encounters[encounters.length - 1]!.round,
+  };
+}
+
+/** Running net win differential (+1 for `a`, -1 for `b`, 0 for neither) across encounters. */
+export function cumulativeNetDiff(encounters: MatchupEncounter[]): number[] {
+  const series: number[] = [];
+  let diff = 0;
+
+  for (const encounter of encounters) {
+    if (encounter.outcome === 'a') {
+      diff += 1;
+    } else if (encounter.outcome === 'b') {
+      diff -= 1;
+    }
+    series.push(diff);
+  }
+
+  return series;
+}


### PR DESCRIPTION
## What

Adds a "Pirate Matchups (Head-to-Head)" tool to the dev modal, mirroring what neobot answers on Discord ("Gooblah and Buck played the same arena 795 times…") but with richer visuals.

## How to test

1. Open dev mode (5 clicks on the footer logo, or 1 click if `localStorage.devModeOpened=true`)
2. Click **Pirate Matchups (Head-to-Head)** in the drawer
3. Defaults are Gooblah vs Buck — verify the summary sentence matches neobot's numbers (shared-arena count, A wins / B wins / neither with percentages)
4. Try the range presets (Last 30/100/500, All time), custom min/max round inputs, the swap button, and changing either pirate's select
5. Scroll to see: head-to-head bar (decided arenas only), longest-run lines, last-25 shared-arena form strip, outcome doughnut, per-arena stacked bars, cumulative net-diff momentum line

## Changes

- `src/app/matchup/pirateMatchups.ts` — pure logic: shared encounters, win/loss/neither split, decided-arena head-to-head rates, per-arena breakdowns, win streaks, cumulative net-diff trend. 11 unit tests.
- `src/app/components/modals/PirateMatchupModal.tsx` — the modal: pirate selectors (self disabled), swap, range presets + custom min/max, neobot-style summary sentence, H2H bar, streak lines, form strip.
- `src/app/components/charts/Matchup{SplitDoughnut,ArenaBarChart,TrendChart}.tsx` — chart.js components.
- `src/app/components/dev/DevModeDrawer.tsx` — entry point button + modal mount.

Reuses the existing `useBacktestPreviousRounds` feed hook (shared in-memory cache, no extra downloads).

## Verification

- `tsc --noEmit` clean; eslint clean on changed files
- Full vitest suite: 934 tests pass (incl. 11 new)
- Playwright smoke test against live feed: all render/interaction checks pass, zero page errors; numbers match neobot's known output for Gooblah vs Buck