### PR TITLE
Replace round input's tiny up/down stepper with left/right buttons

### DIFF
--- a/src/app/components/inputs/RoundInput.tsx
+++ b/src/app/components/inputs/RoundInput.tsx
@@ -1,5 +1,6 @@
-import { Group, NumberInputControl, Text } from '@chakra-ui/react';
+import { Group, Text, chakra } from '@chakra-ui/react';
 import { useEffect, useState, useMemo, useCallback } from 'react';
+import { FaChevronLeft, FaChevronRight } from 'react-icons/fa6';
 
 import { useDebouncedRoundInput } from '../../hooks/useDebouncedRoundInput';
 import { useSelectOnFocus } from '../../hooks/useSelectOnFocus';
@@ -24,6 +25,30 @@ interface RoundInputProps {
   /** Falls back to the store's error state when omitted. */
   hasError?: boolean;
 }
+
+// Full-height left/right stepper buttons (replacing the old tiny up/down control) for
+// easier tapping on mobile. Each carries a full 1px border; the attached Group overlaps
+// adjacent borders via negative margins so the whole control reads as one rounded box.
+const StepperButton = chakra('button', {
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    h: '8',
+    w: '7',
+    flexShrink: 0,
+    fontSize: 'sm',
+    lineHeight: '1',
+    color: 'fg.muted',
+    bg: 'bg.subtle',
+    borderWidth: '1px',
+    cursor: 'pointer',
+    userSelect: 'none',
+    transitionProperty: 'common',
+    _hover: { bg: 'bg.muted' },
+    _active: { bg: 'bg.emphasized' },
+  },
+});
 
 // this element is the number input to say which round's data you're viewing
 
@@ -109,6 +134,23 @@ const RoundInput: React.FC<RoundInputProps> = ({
     setTempValue(roundNumber.toString());
   }, [tempValue, currentRound]);
 
+  // Step the displayed round by +/-1 (clamped at min 1, matching NumberInputRoot's min).
+  // Steps from whatever is currently displayed, falling back to the selected round when
+  // empty/invalid. Like typing, this flows through tempValue + the debounced commit.
+  const stepRoundInput = useCallback(
+    (delta: number): void => {
+      const displayed = parseInt(tempValue, 10);
+      const base = isNaN(displayed) ? currentSelectedRound || 0 : displayed;
+      setTempValue(Math.max(1, base + delta).toString());
+    },
+    [tempValue, currentSelectedRound],
+  );
+
+  const stepperButtonProps = {
+    borderColor: hasError ? 'border.error' : 'border',
+    rounded: 0,
+  } as const;
+
   return (
     <Group attached w="full" gap={0} alignItems="stretch">
       <Text
@@ -119,7 +161,7 @@ const RoundInput: React.FC<RoundInputProps> = ({
         bg="bg.muted"
         borderWidth="1px"
         borderEndWidth="0"
-        borderColor="border"
+        borderColor={hasError ? 'border.error' : 'border'}
         roundedStart="md"
         roundedEnd={0}
         px="2"
@@ -130,25 +172,47 @@ const RoundInput: React.FC<RoundInputProps> = ({
       >
         Round
       </Text>
+      <StepperButton
+        {...stepperButtonProps}
+        type="button"
+        aria-label="Previous round"
+        data-testid="round-input-decrement"
+        onClick={(): void => stepRoundInput(-1)}
+      >
+        <FaChevronLeft />
+      </StepperButton>
       <NumberInputRoot
         value={tempValue}
         min={1}
         allowMouseWheel
+        showControl={false}
         onValueChange={handleChange}
         name="round-input"
         data-testid="round-input"
         size="xs"
         invalid={hasError}
+        flex="1"
+        minW="0"
       >
         <NumberInputField
           onFocus={selectRoundInput}
           onBlur={commitRoundInput}
           name="round-input-field"
           data-testid="round-input-field"
-          roundedStart={0}
+          rounded={0}
+          pe="2"
         />
-        <NumberInputControl />
       </NumberInputRoot>
+      <StepperButton
+        {...stepperButtonProps}
+        type="button"
+        aria-label="Next round"
+        data-testid="round-input-increment"
+        roundedEnd="md"
+        onClick={(): void => stepRoundInput(1)}
+      >
+        <FaChevronRight />
+      </StepperButton>
     </Group>
   );
 };

--- a/src/app/components/inputs/__tests__/RoundInput.test.tsx
+++ b/src/app/components/inputs/__tests__/RoundInput.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { render, screen, fireEvent, waitFor } from '../../../../test/utils';
+import RoundInput from '../RoundInput';
+
+// The component falls back to the round store only when the relevant props are omitted and
+// for its `error` state (null by default). Passing selectedRound/referenceRound/onRoundChange
+// keeps these tests hermetic: no store setup and no network fetches (onRoundChange replaces
+// the store's updateSelectedRound, which would otherwise trigger a round-data fetch).
+
+const noop = vi.fn<() => void>();
+
+// The underlying Chakra/Ark number input syncs its DOM value on requestAnimationFrame and
+// moves between machine states via microtasks, so assertions about the displayed value must
+// go through waitFor (a synchronous expect right after a click runs before the DOM is synced).
+
+describe('RoundInput', () => {
+  it('renders the left (previous) and right (next) stepper buttons', () => {
+    render(<RoundInput selectedRound={8000} referenceRound={8001} onRoundChange={noop} />);
+
+    const prev = screen.getByRole('button', { name: 'Previous round' });
+    const next = screen.getByRole('button', { name: 'Next round' });
+
+    expect(prev).toHaveAttribute('data-testid', 'round-input-decrement');
+    expect(next).toHaveAttribute('data-testid', 'round-input-increment');
+  });
+
+  it('shows the selected round in the input', () => {
+    render(<RoundInput selectedRound={8000} referenceRound={8001} onRoundChange={noop} />);
+
+    expect(screen.getByTestId('round-input-field')).toHaveValue('8000');
+  });
+
+  it('steps forward and back with the left/right buttons', async () => {
+    render(<RoundInput selectedRound={8000} referenceRound={8001} onRoundChange={noop} />);
+
+    const field = screen.getByTestId('round-input-field');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next round' }));
+    await waitFor(() => expect(field).toHaveValue('8001'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Previous round' }));
+    await waitFor(() => expect(field).toHaveValue('8000'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Previous round' }));
+    await waitFor(() => expect(field).toHaveValue('7999'));
+  });
+
+  it('clamps at the minimum round of 1 when stepping backwards', async () => {
+    render(<RoundInput selectedRound={1} referenceRound={2} onRoundChange={noop} />);
+
+    const field = screen.getByTestId('round-input-field');
+    fireEvent.click(screen.getByRole('button', { name: 'Previous round' }));
+
+    // 1 - 1 would be 0, but rounds are clamped at the min of 1.
+    await waitFor(() => expect(field).toHaveValue('1'));
+  });
+
+  it('commits the stepped round through onRoundChange after the debounce delay', async () => {
+    const onRoundChange = vi.fn();
+    render(<RoundInput selectedRound={8000} referenceRound={8001} onRoundChange={onRoundChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next round' }));
+
+    // The 400ms debounce elapses and the new round is committed.
+    await waitFor(() => expect(onRoundChange).toHaveBeenCalledWith(8001));
+  });
+
+  it('keeps the typed-input path working (typing still updates and commits)', async () => {
+    const onRoundChange = vi.fn();
+    render(<RoundInput selectedRound={8000} referenceRound={8001} onRoundChange={onRoundChange} />);
+
+    const field = screen.getByTestId('round-input-field');
+    // zag only handles INPUT.CHANGE once the input is focused (machine state), so focus first
+    // and give its microtask transition a beat before typing. It reads the native `input`
+    // event, so dispatch that rather than change.
+    fireEvent.focus(field);
+    await new Promise(r => setTimeout(r, 0));
+
+    fireEvent.input(field, { target: { value: '9999' } });
+    await waitFor(() => expect(onRoundChange).toHaveBeenCalledWith(9999));
+  });
+});


### PR DESCRIPTION
## What

The header round selector used the number input's vertical up/down control, which is a ~16px-wide column of tiny buttons — very hard to tap on mobile. This swaps it for full-height left/right chevron buttons flanking the field:

`Round | ‹ | 8042 | ›` — styled as one attached rounded box, the same pattern MaxBetInput already uses.

## Details

- `stepRoundInput(delta)` steps whatever is currently displayed (falling back to the selected round when empty/invalid), clamped at min 1, and flows through `tempValue` + the existing 400ms debounced commit — identical path to typing, so it triggers the same round-data fetch/polling.
- `showControl={false}` disables the wrapper's default up/down control so only the new buttons render.
- The field gets `rounded={0}` + padding tweaks to sit flush inside the attached group; error state now tints the label and button borders too (previously only the input border).
- Preserved both e2e testids (`round-input`, `round-input-field`) and added `round-input-decrement`/`round-input-increment` + aria-labels for the new buttons.
- New component test (6 cases): button rendering, displayed value, stepping forward/back, min-1 clamp, debounced commit via `onRoundChange`, and the preserved typed-input path.

## Verification

- Full unit suite: 60 files / 929 tests passing
- `tsc --noEmit` clean, ESLint clean