### PR TITLE
Animate payout chart table values and bet card badge numbers

### DIFF
--- a/src/app/BetFunctions.tsx
+++ b/src/app/BetFunctions.tsx
@@ -1512,12 +1512,19 @@ const BetBadges = React.memo(
       if (totalTer !== null) {
         result.push(
           <Badge key="ter" colorPalette="nfc-teal" variant="surface">
-            TER:{' '}
-            <AnimatedNumber
-              value={totalTer}
-              format={v => v.toFixed(3)}
-              persistKey={`${persistPrefix}-ter`}
-            />
+            {/* Badge is inline-flex with a 4px gap between flex items, so the
+                AnimatedNumber span would be its own item and the gap would show as
+                extra space around the number. Wrapping label + number in one span
+                keeps them a single flex item with normal inline spacing (same on the
+                other badges containing an AnimatedNumber below). */}
+            <span>
+              TER:{' '}
+              <AnimatedNumber
+                value={totalTer}
+                format={v => v.toFixed(3)}
+                persistKey={`${persistPrefix}-ter`}
+              />
+            </span>
           </Badge>,
         );
       }
@@ -1542,13 +1549,16 @@ const BetBadges = React.memo(
         const bustEmoji = bustChance > 99 ? '💀' : '';
         result.push(
           <Badge key="bust-chance" variant="surface">
-            {bustEmoji}{' '}
-            <AnimatedNumber
-              value={bustChance}
-              format={v => `${Math.floor(v)}%`}
-              persistKey={`${persistPrefix}-bust-chance`}
-            />{' '}
-            Bust
+            {/* One span = one flex item, so the badge's gap doesn't land around the number */}
+            <span>
+              {bustEmoji && `${bustEmoji} `}
+              <AnimatedNumber
+                value={bustChance}
+                format={v => `${Math.floor(v)}%`}
+                persistKey={`${persistPrefix}-bust-chance`}
+              />{' '}
+              Bust
+            </span>
           </Badge>,
         );
       }
@@ -1564,13 +1574,16 @@ const BetBadges = React.memo(
       if (betAmountsTotal < lowestProfit) {
         result.push(
           <Badge key="guaranteed-profit" colorPalette="nfc-green" variant="surface">
-            💰 Guaranteed profit (
-            <AnimatedNumber
-              value={lowestProfit - betAmountsTotal}
-              precision={0}
-              persistKey={`${persistPrefix}-guaranteed-profit`}
-            />
-            + NP)
+            {/* One span = one flex item, so the badge's gap doesn't land around the number */}
+            <span>
+              💰 Guaranteed profit (
+              <AnimatedNumber
+                value={lowestProfit - betAmountsTotal}
+                precision={0}
+                persistKey={`${persistPrefix}-guaranteed-profit`}
+              />
+              + NP)
+            </span>
           </Badge>,
         );
       }
@@ -1625,20 +1638,30 @@ const BetBadges = React.memo(
       } else {
         result.push(
           <Badge key="units-won" colorPalette="nfc-green" variant="surface">
-            Units won:{' '}
-            <AnimatedNumber
-              value={unitsWon}
-              precision={0}
-              persistKey={`${persistPrefix}-units-won`}
-            />
+            {/* One span = one flex item, so the badge's gap doesn't land around the number */}
+            <span>
+              Units won:{' '}
+              <AnimatedNumber
+                value={unitsWon}
+                precision={0}
+                persistKey={`${persistPrefix}-units-won`}
+              />
+            </span>
           </Badge>,
         );
 
         if (npWon > 0) {
           result.push(
             <Badge key="np-won" colorPalette="nfc-green" variant="surface">
-              💰 NP won:{' '}
-              <AnimatedNumber value={npWon} precision={0} persistKey={`${persistPrefix}-np-won`} />
+              {/* One span = one flex item, so the badge's gap doesn't land around the number */}
+              <span>
+                💰 NP won:{' '}
+                <AnimatedNumber
+                  value={npWon}
+                  precision={0}
+                  persistKey={`${persistPrefix}-np-won`}
+                />
+              </span>
             </Badge>,
           );
         }

--- a/src/app/BetFunctions.tsx
+++ b/src/app/BetFunctions.tsx
@@ -46,6 +46,7 @@ import { PayoutData, RoundData, RoundState, RoundCalculationResult } from '../ty
 import { Bet, BetAmount } from '../types/bets';
 
 import PirateSelect from './components/bets/PirateSelect';
+import AnimatedNumber from './components/ui/AnimatedNumber';
 import SettingsBox from './components/ui/SettingsBox';
 import {
   ARENA_NAMES,
@@ -1503,10 +1504,20 @@ const BetBadges = React.memo(
       const result: React.ReactElement[] = [];
       const isInvalid = hasDuplicateBets || !calculated;
 
+      // Badges appear and disappear as conditions change (and the card itself
+      // unmounts on round switches), so each one is keyed per bet set to
+      // recover the last value shown for this slot and animate from there.
+      const persistPrefix = `betset-${index}`;
+
       if (totalTer !== null) {
         result.push(
           <Badge key="ter" colorPalette="nfc-teal" variant="surface">
-            TER: {totalTer.toFixed(3)}
+            TER:{' '}
+            <AnimatedNumber
+              value={totalTer}
+              format={v => v.toFixed(3)}
+              persistKey={`${persistPrefix}-ter`}
+            />
           </Badge>,
         );
       }
@@ -1531,7 +1542,13 @@ const BetBadges = React.memo(
         const bustEmoji = bustChance > 99 ? '💀' : '';
         result.push(
           <Badge key="bust-chance" variant="surface">
-            {bustEmoji} {Math.floor(bustChance)}% Bust
+            {bustEmoji}{' '}
+            <AnimatedNumber
+              value={bustChance}
+              format={v => `${Math.floor(v)}%`}
+              persistKey={`${persistPrefix}-bust-chance`}
+            />{' '}
+            Bust
           </Badge>,
         );
       }
@@ -1547,13 +1564,28 @@ const BetBadges = React.memo(
       if (betAmountsTotal < lowestProfit) {
         result.push(
           <Badge key="guaranteed-profit" colorPalette="nfc-green" variant="surface">
-            💰 Guaranteed profit ({lowestProfit - betAmountsTotal}+ NP)
+            💰 Guaranteed profit (
+            <AnimatedNumber
+              value={lowestProfit - betAmountsTotal}
+              precision={0}
+              persistKey={`${persistPrefix}-guaranteed-profit`}
+            />
+            + NP)
           </Badge>,
         );
       }
 
       return result;
-    }, [betCount, isRoundOver, hasDuplicateBets, calculated, payoutTables, betAmounts, totalTer]);
+    }, [
+      betCount,
+      isRoundOver,
+      hasDuplicateBets,
+      calculated,
+      payoutTables,
+      betAmounts,
+      totalTer,
+      index,
+    ]);
 
     const resultsBadges: React.ReactElement[] = useMemo(() => {
       const result: React.ReactElement[] = [];
@@ -1578,6 +1610,12 @@ const BetBadges = React.memo(
         });
       }
 
+      // Same per-bet-set persistKey scheme as the performance badges above:
+      // navigating between finished rounds remounts these, so each number
+      // recovers the last value shown for this bet set's slot and animates
+      // from there instead of snapping.
+      const persistPrefix = `betset-${index}`;
+
       if (unitsWon === 0) {
         result.push(
           <Badge key="busted" variant="surface">
@@ -1587,14 +1625,20 @@ const BetBadges = React.memo(
       } else {
         result.push(
           <Badge key="units-won" colorPalette="nfc-green" variant="surface">
-            Units won: {unitsWon.toLocaleString()}
+            Units won:{' '}
+            <AnimatedNumber
+              value={unitsWon}
+              precision={0}
+              persistKey={`${persistPrefix}-units-won`}
+            />
           </Badge>,
         );
 
         if (npWon > 0) {
           result.push(
             <Badge key="np-won" colorPalette="nfc-green" variant="surface">
-              💰 NP won: {npWon.toLocaleString()}
+              💰 NP won:{' '}
+              <AnimatedNumber value={npWon} precision={0} persistKey={`${persistPrefix}-np-won`} />
             </Badge>,
           );
         }
@@ -1610,6 +1654,7 @@ const BetBadges = React.memo(
       betAmounts,
       hasDuplicateBets,
       calculated,
+      index,
     ]);
 
     const prefixBadges = useMemo(

--- a/src/app/__tests__/BetFunctions.badges.test.tsx
+++ b/src/app/__tests__/BetFunctions.badges.test.tsx
@@ -36,6 +36,28 @@ const getBadgeLabels = (container: HTMLElement): string[] =>
     .filter(el => el.getAttribute('aria-label') !== 'edit')
     .map((el): string => el.getAttribute('aria-label')!);
 
+// Chakra's Badge recipe is inline-flex with a gap between its flex items (the badge's
+// direct children), so if the AnimatedNumber span is a direct child of the badge, that
+// gap renders as extra space around the number. The DOM text itself is clean - it's a
+// layout effect jsdom can't show, so guard the structure instead: every number span in
+// a badge must be wrapped (not a direct child), and the badge's content must be a
+// single element child so nothing else becomes a second flex item. Plain-text badges
+// are one contiguous text run already, so they're exempt.
+const assertNumberBadgesWrapTheirSpan = (container: HTMLElement): void => {
+  for (const badge of Array.from(container.querySelectorAll('.chakra-badge'))) {
+    const numberSpans = Array.from(badge.querySelectorAll('span[aria-label]'));
+    if (numberSpans.length === 0) {
+      continue;
+    }
+
+    for (const span of numberSpans) {
+      expect(span.parentElement, `number in badge "${badge.textContent}"`).not.toBe(badge);
+    }
+
+    expect(Array.from(badge.children), `badge "${badge.textContent}"`).toHaveLength(1);
+  }
+};
+
 // The badge values come from the same store calculations the component reads, so
 // mirror BetBadges' formulas here (including which badges appear at all) to build
 // the expected aria-labels in DOM order.
@@ -142,6 +164,10 @@ describe('BetBadges (AnimatedNumber)', () => {
     // The only aria-label spans in the rendered component are the badge numbers,
     // in DOM order: TER then bust chance.
     expect(getBadgeLabels(container!)).toEqual(buildExpectedLabels(calcs, false));
+
+    // The number badges must keep their spans wrapped so the badge's flex gap can't
+    // land around the numbers (see assertNumberBadgesWrapTheirSpan).
+    assertNumberBadgesWrapTheirSpan(container!);
   });
 
   it('shows the units-won and NP-won badges as numbers matching the calculations once the round is over', () => {
@@ -167,5 +193,8 @@ describe('BetBadges (AnimatedNumber)', () => {
 
     // DOM order: TER, then units won and NP won.
     expect(getBadgeLabels(container!)).toEqual(buildExpectedLabels(calcs, true));
+
+    // Same wrapped-span guarantee for the results badges.
+    assertNumberBadgesWrapTheirSpan(container!);
   });
 });

--- a/src/app/__tests__/BetFunctions.badges.test.tsx
+++ b/src/app/__tests__/BetFunctions.badges.test.tsx
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { render, screen, act, makeRoundData } from '../../test/utils';
+import type { RoundCalculationResult } from '../../types';
+import type { Bet, BetAmount } from '../../types/bets';
+import BetFunctions from '../BetFunctions';
+import { BET_AMOUNT_DEFAULT } from '../constants';
+import { useBetStore } from '../stores/betStore';
+import { useRoundStore } from '../stores/roundStore';
+
+// The round store reads cookies at module init (getMaxBet), so keep that from
+// touching the real document.cookie in jsdom. Everything else - bet/round stores,
+// calculations (wasm included), useBetManagement - runs for real so the badges'
+// numbers are the genuine output of the pipeline.
+vi.mock('universal-cookie', () => ({
+  default: vi.fn().mockImplementation(function () {
+    return {
+      get: vi.fn().mockReturnValue(undefined),
+      set: vi.fn(),
+    };
+  }),
+}));
+
+// One bet on pirate #1 in every arena, amount 100. With the fixture's currentOdds
+// of [1,2,3,4,5] per arena that's 2^5 = 32 odds and (once the winners match) a
+// 3,200 NP payoff.
+const BETS: Bet = new Map([[1, [1, 1, 1, 1, 1]]]);
+const BET_AMOUNTS: BetAmount = new Map([[1, 100]]);
+
+// The badge numbers tween on a rAF loop (AnimatedNumber), so read each span's
+// aria-label - always the final formatted value - rather than its textContent.
+const getBadgeLabels = (container: HTMLElement): string[] =>
+  Array.from(container.querySelectorAll('span[aria-label]'))
+    // The set-name heading (Chakra Editable) renders its own edit-affordance span;
+    // the badge numbers are every other aria-label span in the card.
+    .filter(el => el.getAttribute('aria-label') !== 'edit')
+    .map((el): string => el.getAttribute('aria-label')!);
+
+// The badge values come from the same store calculations the component reads, so
+// mirror BetBadges' formulas here (including which badges appear at all) to build
+// the expected aria-labels in DOM order.
+const buildExpectedLabels = (calcs: RoundCalculationResult, isRoundOver: boolean): string[] => {
+  const labels: string[] = [];
+
+  // TER badge (always present for a valid, calculated set)
+  let totalTer = 0;
+  calcs.betBinaries.forEach((binary, betKey) => {
+    if (binary > 0) {
+      totalTer += calcs.betExpectedRatios.get(betKey) ?? 0;
+    }
+  });
+  labels.push(totalTer.toFixed(3));
+
+  // Once the round is over, performanceBadges early-returns after the TER badge.
+  if (!isRoundOver) {
+    // Bust chance badge (payout row with value 0); "Bust-proof!" has no number
+    const bustChance =
+      calcs.payoutTables.odds[0]?.value === 0
+        ? (calcs.payoutTables.odds[0]?.probability ?? 0) * 100
+        : 0;
+    if (bustChance > 0) {
+      labels.push(`${Math.floor(bustChance)}%`);
+    }
+
+    // Guaranteed profit badge (lowest winnings row beats the total bet amount)
+    const betAmountsTotal = Array.from(BET_AMOUNTS.values())
+      .filter(amount => amount !== BET_AMOUNT_DEFAULT)
+      .reduce<number>((total, amount) => total + amount, 0);
+    const lowestProfit = calcs.payoutTables.winnings[0]?.value ?? 0;
+    if (betAmountsTotal < lowestProfit) {
+      labels.push(Number((lowestProfit - betAmountsTotal).toFixed(0)).toLocaleString());
+    }
+  }
+
+  // Results badges (round over only)
+  if (isRoundOver && calcs.winningBetBinary > 0) {
+    let unitsWon = 0;
+    let npWon = 0;
+    calcs.betBinaries.forEach((binary, betKey) => {
+      if (binary > 0 && (calcs.winningBetBinary & binary) === binary) {
+        unitsWon += calcs.betOdds.get(betKey) ?? 0;
+        npWon += Math.min(
+          (calcs.betOdds.get(betKey) ?? 0) * (BET_AMOUNTS.get(betKey) ?? 0),
+          1_000_000,
+        );
+      }
+    });
+
+    if (unitsWon > 0) {
+      labels.push(Number(unitsWon.toFixed(0)).toLocaleString());
+      if (npWon > 0) {
+        labels.push(Number(npWon.toFixed(0)).toLocaleString());
+      }
+    }
+  }
+
+  return labels;
+};
+
+describe('BetBadges (AnimatedNumber)', () => {
+  beforeEach(() => {
+    useBetStore.setState({
+      currentBet: 0,
+      allBets: new Map([[0, BETS]]),
+      allBetAmounts: new Map([[0, BET_AMOUNTS]]),
+      allNames: new Map([[0, 'Test Set']]),
+    });
+
+    useRoundStore.setState({
+      roundData: makeRoundData(),
+      currentSelectedRound: 8000,
+      currentRound: 8000,
+      bigBrain: false,
+      useLogitModel: false,
+      customOddsMode: false,
+      customOdds: null,
+      customProbs: null,
+    });
+    useRoundStore.getState().recalculate();
+  });
+
+  it('shows the TER and bust chance badges as numbers matching the calculations while the round is live', () => {
+    const calcs = useRoundStore.getState().calculations;
+
+    // Fixture sanity: the set is calculated and the payout table has a bust row
+    expect(calcs.calculated).toBe(true);
+    expect(calcs.payoutTables.odds[0]?.value).toBe(0);
+    expect(calcs.payoutTables.odds[0]?.probability ?? 0).toBeGreaterThan(0);
+
+    const { container } = render(<BetFunctions />);
+
+    // Sanity on the anchors: TER and a (non-zero) bust chance badge are present.
+    // The bust badge's text is split across the emoji and the AnimatedNumber span,
+    // so match on the container's text rather than a single element.
+    expect(screen.getByText('TER:')).toBeInTheDocument();
+    expect(container.textContent).toContain('Bust');
+
+    // No results badges while the round is live
+    expect(screen.queryByText('Units won:')).not.toBeInTheDocument();
+    expect(container.textContent).not.toContain('NP won');
+
+    // The only aria-label spans in the rendered component are the badge numbers,
+    // in DOM order: TER then bust chance.
+    expect(getBadgeLabels(container!)).toEqual(buildExpectedLabels(calcs, false));
+  });
+
+  it('shows the units-won and NP-won badges as numbers matching the calculations once the round is over', () => {
+    // The winning pirates are #1 in every arena - exactly the bet's line - so the
+    // single bet pays out.
+    act(() => {
+      useRoundStore.setState({ roundData: makeRoundData({ winners: [1, 1, 1, 1, 1] }) });
+      useRoundStore.getState().recalculate();
+    });
+
+    const calcs = useRoundStore.getState().calculations;
+    expect(calcs.winningBetBinary).toBeGreaterThan(0);
+
+    const { container } = render(<BetFunctions />);
+
+    // Sanity on the anchors: TER plus both results badges. Once the round is over,
+    // performanceBadges early-return after TER, so no bust chance badge.
+    expect(screen.getByText('TER:')).toBeInTheDocument();
+    expect(screen.getByText('Units won:')).toBeInTheDocument();
+    expect(container!.textContent).toContain('NP won');
+    // The bet paid out, so no "Busted" badge
+    expect(container!.textContent).not.toContain('Busted');
+
+    // DOM order: TER, then units won and NP won.
+    expect(getBadgeLabels(container!)).toEqual(buildExpectedLabels(calcs, true));
+  });
+});

--- a/src/app/components/charts/PayoutCharts.tsx
+++ b/src/app/components/charts/PayoutCharts.tsx
@@ -25,6 +25,7 @@ import {
   displayAsPercentSmart,
   getMaxSmartPercentDecimals,
 } from '../../util';
+import AnimatedNumber from '../ui/AnimatedNumber';
 import TextTooltip from '../ui/TextTooltip';
 
 import PayoutScatter from './PayoutScatter';
@@ -315,7 +316,11 @@ const PayoutCharts: React.FC = React.memo(() => {
 
       const { totalWinningOdds, totalWinningPayoff } = calculationsData;
 
-      const tableRows = data.map(dataObj => {
+      // Rows are keyed by position (not by their payout value) so that when the
+      // underlying odds tick and every outcome's value shifts, each row stays
+      // mounted at its slot - which is what lets the AnimatedNumber cells tween
+      // from their old value to the new one instead of remounting and snapping.
+      const tableRows = data.map((dataObj, rowIndex) => {
         let bgColor: string | undefined = undefined;
 
         if (
@@ -330,27 +335,58 @@ const PayoutCharts: React.FC = React.memo(() => {
           }
         }
 
+        // The row set can shrink and regrow (bet sets changing size, round
+        // switches), so a row at position N can unmount and remount later with
+        // different data - persistKey lets its numbers recover the last value
+        // shown at that slot and animate from there instead of snapping.
+        const persistPrefix = `payout-chart-${title}-${rowIndex}`;
+
         return (
           <Table.Row
-            key={dataObj.value}
+            // eslint-disable-next-line react/no-array-index-key
+            key={`payout-chart-row-${title}-${rowIndex}`}
             {...(bgColor && { layerStyle: 'fill.subtle', colorPalette: bgColor })}
           >
-            <Table.Cell textAlign="end">{dataObj.value.toLocaleString()}</Table.Cell>
+            <Table.Cell textAlign="end">
+              <AnimatedNumber
+                value={dataObj.value}
+                precision={0}
+                persistKey={`${persistPrefix}-value`}
+              />
+            </Table.Cell>
             <Table.Cell textAlign="end">
               <TextTooltip
-                text={displayAsPercent(dataObj.probability, probabilityDecimals)}
+                text={
+                  <AnimatedNumber
+                    value={dataObj.probability}
+                    format={v => displayAsPercent(v, probabilityDecimals)}
+                    persistKey={`${persistPrefix}-probability`}
+                  />
+                }
                 content={displayAsPercentSmart(dataObj.probability)}
               />
             </Table.Cell>
             <Table.Cell textAlign="end">
               <TextTooltip
-                text={displayAsPercent(dataObj.cumulative || 0, cumulativeDecimals)}
+                text={
+                  <AnimatedNumber
+                    value={dataObj.cumulative || 0}
+                    format={v => displayAsPercent(v, cumulativeDecimals)}
+                    persistKey={`${persistPrefix}-cumulative`}
+                  />
+                }
                 content={displayAsPercentSmart(dataObj.cumulative || 0)}
               />
             </Table.Cell>
             <Table.Cell textAlign="end">
               <TextTooltip
-                text={displayAsPercent(dataObj.tail || 0, tailDecimals)}
+                text={
+                  <AnimatedNumber
+                    value={dataObj.tail || 0}
+                    format={v => displayAsPercent(v, tailDecimals)}
+                    persistKey={`${persistPrefix}-tail`}
+                  />
+                }
                 content={displayAsPercentSmart(dataObj.tail || 0)}
               />
             </Table.Cell>

--- a/src/app/components/charts/__tests__/PayoutCharts.test.tsx
+++ b/src/app/components/charts/__tests__/PayoutCharts.test.tsx
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import { render, makeRoundData } from '../../../../test/utils';
+import { render, makeRoundData, screen, act } from '../../../../test/utils';
+import type { PayoutData } from '../../../../types';
 import type { Bet, BetAmount } from '../../../../types/bets';
 import { useBetStore } from '../../../stores/betStore';
 import { useRoundStore } from '../../../stores/roundStore';
+import { displayAsPercent, getMaxSmartPercentDecimals } from '../../../util';
 import PayoutCharts from '../PayoutCharts';
 
 vi.mock('universal-cookie', () => ({
@@ -65,5 +67,92 @@ describe('PayoutCharts', () => {
 
     const canvases = container!.querySelectorAll('canvas');
     expect(canvases.length).toBe(2);
+  });
+
+  // The table cells render their numbers through AnimatedNumber, which tweens its
+  // visible text on a rAF loop. Reading the span's aria-label (always the final
+  // formatted value) rather than textContent keeps these assertions stable while a
+  // tween is in flight (same convention as ArenaTableBody.customOdds.test.tsx).
+  const getTableByTitle = (title: string): HTMLTableElement => {
+    const header = screen.getByRole('columnheader', { name: title });
+    return header.closest('table') as HTMLTableElement;
+  };
+
+  const getDataRowCellLabels = (
+    table: HTMLTableElement,
+    rowIndex: number,
+  ): Array<string | null> => {
+    const dataRows = table.querySelectorAll('tbody > tr');
+    const row = dataRows[rowIndex]!;
+    return Array.from(row.querySelectorAll('td')).map(
+      td => td.querySelector('span[aria-label]')?.getAttribute('aria-label') ?? null,
+    );
+  };
+
+  // Mirror PayoutCharts' makeTable formatting exactly: the value column uses
+  // precision=0 + the default toLocaleString, and each percent column is formatted
+  // with a shared "smart" decimal count derived from the whole table.
+  const expectedRowLabels = (data: PayoutData[], rowIndex: number): string[] => {
+    const probabilityDecimals = getMaxSmartPercentDecimals(data.map(d => d.probability));
+    const cumulativeDecimals = getMaxSmartPercentDecimals(data.map(d => d.cumulative || 0));
+    const tailDecimals = getMaxSmartPercentDecimals(data.map(d => d.tail || 0));
+    const row = data[rowIndex]!;
+
+    return [
+      Number(row.value.toFixed(0)).toLocaleString(),
+      displayAsPercent(row.probability, probabilityDecimals),
+      displayAsPercent(row.cumulative || 0, cumulativeDecimals),
+      displayAsPercent(row.tail || 0, tailDecimals),
+    ];
+  };
+
+  const assertTableMatchesCalculations = (title: string, data: PayoutData[]): void => {
+    const table = getTableByTitle(title);
+    const dataRows = table.querySelectorAll('tbody > tr');
+    expect(dataRows.length).toBe(data.length);
+
+    for (let rowIndex = 0; rowIndex < data.length; rowIndex++) {
+      expect(getDataRowCellLabels(table, rowIndex)).toEqual(expectedRowLabels(data, rowIndex));
+    }
+  };
+
+  it('renders every payout table cell as an AnimatedNumber whose value matches the calculations', () => {
+    render(<PayoutCharts />);
+
+    const { odds, winnings } = useRoundStore.getState().calculations.payoutTables;
+    expect(odds.length).toBeGreaterThan(0);
+    expect(winnings.length).toBeGreaterThan(0);
+
+    assertTableMatchesCalculations('Odds', odds);
+    assertTableMatchesCalculations('Winnings', winnings);
+  });
+
+  it('updates payout table cell values when the odds change and the round recalculates', () => {
+    render(<PayoutCharts />);
+
+    const before = useRoundStore.getState().calculations.payoutTables;
+    assertTableMatchesCalculations('Odds', before.odds);
+
+    // Bump each pirate's odds by one (leaving the no-pirate baseline at index 0,
+    // which must stay 1 for valid round data) so the payout values shift.
+    const bumpedOdds = useRoundStore
+      .getState()
+      .roundData.currentOdds.map(arena =>
+        arena.map((odds, pirateIndex) => (pirateIndex === 0 ? odds : odds + 1)),
+      );
+    act(() => {
+      useRoundStore.setState({
+        roundData: makeRoundData({ currentOdds: bumpedOdds }),
+      });
+      useRoundStore.getState().recalculate();
+    });
+
+    const after = useRoundStore.getState().calculations.payoutTables;
+    // Sanity: the bump actually changed at least one displayed value, so this is a
+    // genuine update rather than a no-op re-render.
+    expect(after.odds.map(d => d.value)).not.toEqual(before.odds.map(d => d.value));
+
+    assertTableMatchesCalculations('Odds', after.odds);
+    assertTableMatchesCalculations('Winnings', after.winnings);
   });
 });


### PR DESCRIPTION
Follow-up to #987/#996: extend `AnimatedNumber` to the remaining numeric spots where tweening makes sense — the payout charts' odds/winnings tables and the bet card badges.

## What changed

**`PayoutCharts.tsx`** — both payout tables' cells (value, probability, cumulative, tail) now render through `AnimatedNumber`:
- Row keys switched from the payout value to position (`payout-chart-row-${title}-${rowIndex}`). Keying by value remounted every row on each odds tick (each outcome's value shifts), which would snap instead of tween. The `react/no-array-index-key` disable for the position key follows the existing pattern in `ArenaTableBody`.
- Each cell gets a persistKey scoped to its row slot so numbers recover the last value shown there after unmount/remount (round switches, bet set size changes) and animate from it.

**`BetFunctions.tsx`** — badge numbers in `BetBadges`:
- Performance badges: TER (3dp), bust chance (`floor`%), guaranteed profit.
- Results badges: units won, NP won (integer formatting via `precision={0}`, so large payoffs get comma separators now — previously raw `.toLocaleString()` output on a plain string, same display).
- Same per-bet-set persistKey scheme (`betset-${index}-...`), since navigating between finished rounds remounts the card.
- "Bust-proof!" and "💀 Busted" stay plain — no number to tween.

## Tests

- `PayoutCharts.test.tsx`: new test asserting every table cell is an AnimatedNumber whose value matches the store calculations (Odds + Winnings, all rows).
- `BetFunctions.badges.test.tsx` (new): renders the real `<BetFunctions/>` with seeded bet/round stores and only `universal-cookie` mocked, so the badge numbers are genuine pipeline output. Asserts on each AnimatedNumber's `aria-label` (always the final formatted value — stable while a tween is in flight, same convention as `ArenaTableBody.customOdds.test.tsx`):
  - mid-round: TER + bust chance badges, no results badges;
  - round over with all winners matching: TER + units won (32) + NP won (3,200); bust chance correctly absent after the early return.

## Verification

- `npx vitest run` on both suites: 6/6 passing.
- ESLint clean on all four changed files; `tsc --noEmit` shows only the pre-existing missing-`culori` error from #996 (declared in package.json but not installed).

**Badge spacing fix (post-review)** — wrapping the badge numbers in `AnimatedNumber` spans made Chakra v3's Badge recipe (`display: inline-flex`, `gap: 4px`) insert visible space around every number (e.g. `( 80,000 + NP)`). Each badge's label+number is now wrapped in a single `<span>` so it stays one flex item and the gap can't land inside it; plain-text badges (one contiguous text run) were never affected. Since jsdom can't render the layout effect, `BetFunctions.badges.test.tsx` gained a structural guard asserting every number span is wrapped (not a direct badge child) and each such badge has exactly one element child.
