### PR TITLE
Add FC Data Visualizer (NeoBot CSV) to dev mode

### DIFF
--- a/src/app/analysis/__tests__/fcDataAdvancedStats.test.ts
+++ b/src/app/analysis/__tests__/fcDataAdvancedStats.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest';
+
+import type { BacktestRound } from '../../backtest/types';
+import type { FcDataRow } from '../../data/fcDataCsv';
+import { wasmBetsIndicesToHash } from '../../wasmMath';
+import { computeAdvancedStats } from '../fcDataAdvancedStats';
+
+/** 5 arenas x 4 pirates: arena N gets pirate IDs [4N+1 .. 4N+4]. */
+function makeRound(round: number): BacktestRound {
+  return {
+    round,
+    pirates: [
+      [1, 2, 3, 4],
+      [5, 6, 7, 8],
+      [9, 10, 11, 12],
+      [13, 14, 15, 16],
+      [17, 18, 19, 20],
+    ],
+    openingOdds: [],
+    currentOdds: [],
+    winners: [1, 1, 1, 1, 1],
+  };
+}
+
+function makeRow(round: number, unitsWon: number, lines: number[][]): FcDataRow {
+  const flat = lines.flat();
+  const hash = wasmBetsIndicesToHash(flat);
+  return {
+    date: new Date(2024, 0, round),
+    rawDate: '',
+    round,
+    unitsWon,
+    url: `https://neofood.club/#round=${round}&b=${hash}`,
+  };
+}
+
+describe('computeAdvancedStats', () => {
+  it('separates matched rounds from unmatched (not present in the feed)', () => {
+    const rows = [
+      makeRow(1, 5, [[1, 0, 0, 0, 0]]),
+      makeRow(2, 5, [[1, 0, 0, 0, 0]]), // no round 2 in the feed
+    ];
+    const roundsByNumber = new Map([[1, makeRound(1)]]);
+    const stats = computeAdvancedStats(rows, roundsByNumber);
+
+    expect(stats.fingerprint.matchedRounds).toBe(1);
+    expect(stats.fingerprint.unmatchedRounds).toBe(1);
+  });
+
+  it('maps decoded arena positions to real pirate identities via the round grid', () => {
+    // Arena 0 position 1 -> pirate 1; arena 1 position 2 -> pirate 6.
+    const rows = [makeRow(1, 10, [[1, 2, 0, 0, 0]])];
+    const roundsByNumber = new Map([[1, makeRound(1)]]);
+    const stats = computeAdvancedStats(rows, roundsByNumber);
+
+    const ids = stats.pirateExposure.map(p => p.pirateId).sort((a, b) => a - b);
+    expect(ids).toEqual([1, 6]);
+    expect(stats.pirateExposure.find(p => p.pirateId === 1)?.name).toBe('Dan');
+  });
+
+  it('classifies a gambit-shaped bet: every arena has at most one distinct position across lines', () => {
+    const rows = [
+      makeRow(1, 10, [
+        [1, 2, 0, 0, 0],
+        [1, 2, 3, 0, 0],
+      ]),
+    ];
+    const roundsByNumber = new Map([[1, makeRound(1)]]);
+    const stats = computeAdvancedStats(rows, roundsByNumber);
+
+    expect(stats.betShapes).toEqual({ gambitShaped: 1, tenbetShaped: 0, other: 0, total: 1 });
+  });
+
+  it('classifies a tenbet-shaped bet: one arena position fixed, others vary', () => {
+    const rows = [
+      makeRow(1, 10, [
+        [1, 2, 0, 0, 0],
+        [1, 3, 0, 0, 0],
+      ]),
+    ];
+    const roundsByNumber = new Map([[1, makeRound(1)]]);
+    const stats = computeAdvancedStats(rows, roundsByNumber);
+
+    expect(stats.betShapes).toEqual({ gambitShaped: 0, tenbetShaped: 1, other: 0, total: 1 });
+  });
+
+  it('classifies as other when no arena is shared and it is not a gambit subset', () => {
+    const rows = [
+      makeRow(1, 10, [
+        [1, 0, 0, 0, 0],
+        [2, 0, 0, 0, 0],
+      ]),
+    ];
+    const roundsByNumber = new Map([[1, makeRound(1)]]);
+    const stats = computeAdvancedStats(rows, roundsByNumber);
+
+    expect(stats.betShapes).toEqual({ gambitShaped: 0, tenbetShaped: 0, other: 1, total: 1 });
+  });
+
+  it('classifies single-line bets as other, not gambit', () => {
+    const rows = [makeRow(1, 10, [[1, 0, 0, 0, 0]])];
+    const roundsByNumber = new Map([[1, makeRound(1)]]);
+    const stats = computeAdvancedStats(rows, roundsByNumber);
+
+    expect(stats.betShapes).toEqual({ gambitShaped: 0, tenbetShaped: 0, other: 1, total: 1 });
+  });
+
+  it('tracks pirate participation rate, average lines when included, and co-occurring units won', () => {
+    const rows = [
+      makeRow(1, 10, [[1, 0, 0, 0, 0]]), // pirate 1 in 1 line
+      makeRow(
+        2,
+        20,
+        [
+          [1, 0, 0, 0, 0],
+          [1, 0, 0, 0, 0],
+        ], // pirate 1 in both lines this round
+      ),
+    ];
+    const roundsByNumber = new Map([
+      [1, makeRound(1)],
+      [2, makeRound(2)],
+    ]);
+    const stats = computeAdvancedStats(rows, roundsByNumber);
+
+    const pirate1 = stats.pirateExposure.find(p => p.pirateId === 1)!;
+    expect(pirate1.roundsIncluded).toBe(2);
+    expect(pirate1.roundParticipationRate).toBe(1);
+    expect(pirate1.averageLinesWhenIncluded).toBe(1.5); // (1 + 2) / 2
+    expect(pirate1.averageUnitsWonWhenIncluded).toBe(15); // (10 + 20) / 2
+  });
+
+  it("identifies the pirate present in every line of a round as that round's anchor", () => {
+    const rows = [
+      makeRow(1, 10, [
+        [1, 2, 0, 0, 0],
+        [1, 3, 0, 0, 0],
+      ]),
+    ];
+    const roundsByNumber = new Map([[1, makeRound(1)]]);
+    const stats = computeAdvancedStats(rows, roundsByNumber);
+
+    expect(stats.favoriteAnchorPirate).toEqual({
+      pirateId: 1,
+      name: 'Dan',
+      anchorRoundCount: 1,
+      share: 1,
+    });
+  });
+
+  it('is null for favoriteAnchorPirate when no round has a consistent anchor', () => {
+    const rows = [
+      makeRow(1, 10, [
+        [1, 0, 0, 0, 0],
+        [2, 0, 0, 0, 0],
+      ]),
+    ];
+    const roundsByNumber = new Map([[1, makeRound(1)]]);
+    const stats = computeAdvancedStats(rows, roundsByNumber);
+
+    expect(stats.favoriteAnchorPirate).toBeNull();
+  });
+
+  it('computes arena usage as a share of all active lines', () => {
+    const rows = [makeRow(1, 10, [[1, 2, 0, 0, 0]])]; // 1 line, picks in arena 0 and 1 only
+    const roundsByNumber = new Map([[1, makeRound(1)]]);
+    const stats = computeAdvancedStats(rows, roundsByNumber);
+
+    expect(stats.arenaUsage[0]).toMatchObject({ name: 'Shipwreck', lineParticipationRate: 1 });
+    expect(stats.arenaUsage[1]).toMatchObject({ name: 'Lagoon', lineParticipationRate: 1 });
+    expect(stats.arenaUsage[2]).toMatchObject({ name: 'Treasure', lineParticipationRate: 0 });
+  });
+
+  it('computes fingerprint averages and the 10-line share', () => {
+    // 10 lines, each with exactly one pick so every line is "active".
+    const tenLines = Array.from({ length: 10 }, (_, i) => {
+      const line = [0, 0, 0, 0, 0];
+      line[i % 5] = (i % 4) + 1;
+      return line;
+    });
+    const rows = [
+      makeRow(1, 10, [[1, 2, 0, 0, 0]]), // 1 line, 2 pirates
+      makeRow(2, 10, tenLines), // 10 active lines
+    ];
+    const roundsByNumber = new Map([
+      [1, makeRound(1)],
+      [2, makeRound(2)],
+    ]);
+    const stats = computeAdvancedStats(rows, roundsByNumber);
+
+    expect(stats.fingerprint.matchedRounds).toBe(2);
+    expect(stats.fingerprint.tenLineShare).toBe(0.5); // 1 of 2 rounds had exactly 10 lines
+  });
+
+  it('returns empty/zeroed results for no rows', () => {
+    const stats = computeAdvancedStats([], new Map());
+    expect(stats.pirateExposure).toEqual([]);
+    expect(stats.favoriteAnchorPirate).toBeNull();
+    expect(stats.fingerprint).toEqual({
+      matchedRounds: 0,
+      unmatchedRounds: 0,
+      averagePiratesPerLine: 0,
+      averageUniquePiratesPerRound: 0,
+      tenLineShare: 0,
+    });
+  });
+});

--- a/src/app/analysis/__tests__/fcDataAdvancedStats.test.ts
+++ b/src/app/analysis/__tests__/fcDataAdvancedStats.test.ts
@@ -58,53 +58,6 @@ describe('computeAdvancedStats', () => {
     expect(stats.pirateExposure.find(p => p.pirateId === 1)?.name).toBe('Dan');
   });
 
-  it('classifies a gambit-shaped bet: every arena has at most one distinct position across lines', () => {
-    const rows = [
-      makeRow(1, 10, [
-        [1, 2, 0, 0, 0],
-        [1, 2, 3, 0, 0],
-      ]),
-    ];
-    const roundsByNumber = new Map([[1, makeRound(1)]]);
-    const stats = computeAdvancedStats(rows, roundsByNumber);
-
-    expect(stats.betShapes).toEqual({ gambitShaped: 1, tenbetShaped: 0, other: 0, total: 1 });
-  });
-
-  it('classifies a tenbet-shaped bet: one arena position fixed, others vary', () => {
-    const rows = [
-      makeRow(1, 10, [
-        [1, 2, 0, 0, 0],
-        [1, 3, 0, 0, 0],
-      ]),
-    ];
-    const roundsByNumber = new Map([[1, makeRound(1)]]);
-    const stats = computeAdvancedStats(rows, roundsByNumber);
-
-    expect(stats.betShapes).toEqual({ gambitShaped: 0, tenbetShaped: 1, other: 0, total: 1 });
-  });
-
-  it('classifies as other when no arena is shared and it is not a gambit subset', () => {
-    const rows = [
-      makeRow(1, 10, [
-        [1, 0, 0, 0, 0],
-        [2, 0, 0, 0, 0],
-      ]),
-    ];
-    const roundsByNumber = new Map([[1, makeRound(1)]]);
-    const stats = computeAdvancedStats(rows, roundsByNumber);
-
-    expect(stats.betShapes).toEqual({ gambitShaped: 0, tenbetShaped: 0, other: 1, total: 1 });
-  });
-
-  it('classifies single-line bets as other, not gambit', () => {
-    const rows = [makeRow(1, 10, [[1, 0, 0, 0, 0]])];
-    const roundsByNumber = new Map([[1, makeRound(1)]]);
-    const stats = computeAdvancedStats(rows, roundsByNumber);
-
-    expect(stats.betShapes).toEqual({ gambitShaped: 0, tenbetShaped: 0, other: 1, total: 1 });
-  });
-
   it('tracks pirate participation rate, average lines when included, and co-occurring units won', () => {
     const rows = [
       makeRow(1, 10, [[1, 0, 0, 0, 0]]), // pirate 1 in 1 line

--- a/src/app/analysis/__tests__/fcDataAdvancedStats.test.ts
+++ b/src/app/analysis/__tests__/fcDataAdvancedStats.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import type { BacktestRound } from '../../backtest/types';
 import type { FcDataRow } from '../../data/fcDataCsv';
 import { wasmBetsIndicesToHash } from '../../wasmMath';
-import { computeAdvancedStats } from '../fcDataAdvancedStats';
+import { computeAdvancedStats, findMissedRoundGapsFromFeed } from '../fcDataAdvancedStats';
 
 /** 5 arenas x 4 pirates: arena N gets pirate IDs [4N+1 .. 4N+4]. */
 function makeRound(round: number): BacktestRound {
@@ -124,16 +124,13 @@ describe('computeAdvancedStats', () => {
     expect(stats.arenaUsage[2]).toMatchObject({ name: 'Treasure', lineParticipationRate: 0 });
   });
 
-  it('computes fingerprint averages and the 10-line share', () => {
-    // 10 lines, each with exactly one pick so every line is "active".
-    const tenLines = Array.from({ length: 10 }, (_, i) => {
-      const line = [0, 0, 0, 0, 0];
-      line[i % 5] = (i % 4) + 1;
-      return line;
-    });
+  it('computes fingerprint averages across matched rounds', () => {
     const rows = [
       makeRow(1, 10, [[1, 2, 0, 0, 0]]), // 1 line, 2 pirates
-      makeRow(2, 10, tenLines), // 10 active lines
+      makeRow(2, 10, [
+        [3, 0, 0, 0, 0],
+        [3, 4, 0, 0, 0],
+      ]), // 2 lines, 2 pirates
     ];
     const roundsByNumber = new Map([
       [1, makeRound(1)],
@@ -142,7 +139,6 @@ describe('computeAdvancedStats', () => {
     const stats = computeAdvancedStats(rows, roundsByNumber);
 
     expect(stats.fingerprint.matchedRounds).toBe(2);
-    expect(stats.fingerprint.tenLineShare).toBe(0.5); // 1 of 2 rounds had exactly 10 lines
   });
 
   it('returns empty/zeroed results for no rows', () => {
@@ -154,7 +150,52 @@ describe('computeAdvancedStats', () => {
       unmatchedRounds: 0,
       averagePiratesPerLine: 0,
       averageUniquePiratesPerRound: 0,
-      tenLineShare: 0,
     });
+  });
+});
+
+function makeSimpleRow(round: number): FcDataRow {
+  return {
+    date: new Date(2024, 0, round),
+    rawDate: '',
+    round,
+    unitsWon: 0,
+    url: `https://neofood.club/#round=${round}`,
+  };
+}
+
+describe('findMissedRoundGapsFromFeed', () => {
+  it('does not report a gap when the missing rounds never existed in the feed', () => {
+    // Rounds 2-4 are absent from the CSV *and* from the feed (e.g. a maintenance outage).
+    const rows = [makeSimpleRow(1), makeSimpleRow(5)];
+    const roundsByNumber = new Map([
+      [1, makeRound(1)],
+      [5, makeRound(5)],
+    ]);
+
+    expect(findMissedRoundGapsFromFeed(rows, roundsByNumber)).toEqual([]);
+  });
+
+  it('reports a gap only for rounds that exist in the feed but are missing from the CSV', () => {
+    const rows = [makeSimpleRow(1), makeSimpleRow(5)];
+    // Rounds 2 and 3 really happened (in the feed); round 4 never did.
+    const roundsByNumber = new Map([
+      [1, makeRound(1)],
+      [2, makeRound(2)],
+      [3, makeRound(3)],
+      [5, makeRound(5)],
+    ]);
+
+    expect(findMissedRoundGapsFromFeed(rows, roundsByNumber)).toEqual([
+      { afterRound: 1, beforeRound: 5, missingCount: 2 },
+    ]);
+  });
+
+  it('returns no gaps for a single-row input', () => {
+    expect(findMissedRoundGapsFromFeed([makeSimpleRow(1)], new Map())).toEqual([]);
+  });
+
+  it('returns no gaps for empty input', () => {
+    expect(findMissedRoundGapsFromFeed([], new Map())).toEqual([]);
   });
 });

--- a/src/app/analysis/__tests__/fcDataStats.test.ts
+++ b/src/app/analysis/__tests__/fcDataStats.test.ts
@@ -6,6 +6,7 @@ import {
   activeBetLineCount,
   computeCumulativeSeries,
   computeMonthlyStats,
+  computeRoiSeries,
   computeTotals,
   findMissedRoundGaps,
 } from '../fcDataStats';
@@ -148,6 +149,33 @@ describe('computeCumulativeSeries', () => {
       expect(series[i]!.cumulative).toBeGreaterThanOrEqual(series[i - 1]!.cumulative);
     }
     expect(series[series.length - 1]!.cumulative).toBe(20);
+  });
+});
+
+describe('computeRoiSeries', () => {
+  it('tracks running cumulative roi per round', () => {
+    const oneLineUrl = makeBetUrl(1, [[1, 0, 0, 0, 0]]);
+    const rows = [
+      makeRow(1, 2, new Date(2024, 0, 1), oneLineUrl), // 2/1 = 2.0x
+      makeRow(2, 0, new Date(2024, 0, 2), oneLineUrl), // (2+0)/(1+1) = 1.0x
+      makeRow(3, 4, new Date(2024, 0, 3), oneLineUrl), // (2+0+4)/(1+1+1) = 2.0x
+    ];
+    const series = computeRoiSeries(rows);
+
+    expect(series).toEqual([
+      { round: 1, roi: 2 },
+      { round: 2, roi: 1 },
+      { round: 3, roi: 2 },
+    ]);
+  });
+
+  it('is 0 for rounds with no active bet lines yet, avoiding division by zero', () => {
+    const rows = [makeRow(1, 5, new Date(2024, 0, 1), 'https://neofood.club/#round=1')];
+    expect(computeRoiSeries(rows)).toEqual([{ round: 1, roi: 0 }]);
+  });
+
+  it('returns an empty series for empty input', () => {
+    expect(computeRoiSeries([])).toEqual([]);
   });
 });
 

--- a/src/app/analysis/__tests__/fcDataStats.test.ts
+++ b/src/app/analysis/__tests__/fcDataStats.test.ts
@@ -5,6 +5,7 @@ import { wasmBetsIndicesToHash } from '../../wasmMath';
 import {
   activeBetLineCount,
   classifyRoundReturn,
+  computeBetShapeCounts,
   computeCumulativeSeries,
   computeMonthlyStats,
   computeReturnDistribution,
@@ -226,6 +227,106 @@ describe('activeBetLineCount', () => {
 
   it('returns 0 for a URL with no bet hash', () => {
     expect(activeBetLineCount('https://neofood.club/#round=1')).toBe(0);
+  });
+});
+
+describe('computeBetShapeCounts', () => {
+  it('classifies a gambit-shaped bet: every arena has at most one distinct position across lines', () => {
+    const url = makeBetUrl(1, [
+      [1, 2, 0, 0, 0],
+      [1, 2, 3, 0, 0],
+    ]);
+    const rows = [makeRow(1, 10, new Date(2024, 0, 1), url)];
+    expect(computeBetShapeCounts(rows)).toEqual({
+      gambitShaped: 1,
+      bustproofShaped: 0,
+      crazyShaped: 0,
+      tenbetShaped: 0,
+      other: 0,
+      total: 1,
+    });
+  });
+
+  it('classifies a bustproof-shaped bet: one arena has all 4 pirates covered', () => {
+    const url = makeBetUrl(1, [
+      [1, 0, 0, 0, 0],
+      [2, 0, 0, 0, 0],
+      [3, 0, 0, 0, 0],
+      [4, 0, 0, 0, 0],
+    ]);
+    const rows = [makeRow(1, 10, new Date(2024, 0, 1), url)];
+    expect(computeBetShapeCounts(rows)).toEqual({
+      gambitShaped: 0,
+      bustproofShaped: 1,
+      crazyShaped: 0,
+      tenbetShaped: 0,
+      other: 0,
+      total: 1,
+    });
+  });
+
+  it('classifies a crazy-shaped bet: every line picks a pirate in all 5 arenas', () => {
+    const url = makeBetUrl(1, [
+      [1, 1, 1, 1, 1],
+      [2, 2, 2, 2, 2],
+    ]);
+    const rows = [makeRow(1, 10, new Date(2024, 0, 1), url)];
+    expect(computeBetShapeCounts(rows)).toEqual({
+      gambitShaped: 0,
+      bustproofShaped: 0,
+      crazyShaped: 1,
+      tenbetShaped: 0,
+      other: 0,
+      total: 1,
+    });
+  });
+
+  it('classifies a tenbet-shaped bet: one arena position fixed, others vary', () => {
+    const url = makeBetUrl(1, [
+      [1, 2, 0, 0, 0],
+      [1, 3, 0, 0, 0],
+    ]);
+    const rows = [makeRow(1, 10, new Date(2024, 0, 1), url)];
+    expect(computeBetShapeCounts(rows)).toEqual({
+      gambitShaped: 0,
+      bustproofShaped: 0,
+      crazyShaped: 0,
+      tenbetShaped: 1,
+      other: 0,
+      total: 1,
+    });
+  });
+
+  it('classifies as other when no arena is shared and it is not a gambit subset', () => {
+    const url = makeBetUrl(1, [
+      [1, 0, 0, 0, 0],
+      [2, 0, 0, 0, 0],
+    ]);
+    const rows = [makeRow(1, 10, new Date(2024, 0, 1), url)];
+    expect(computeBetShapeCounts(rows)).toEqual({
+      gambitShaped: 0,
+      bustproofShaped: 0,
+      crazyShaped: 0,
+      tenbetShaped: 0,
+      other: 1,
+      total: 1,
+    });
+  });
+
+  it('classifies single-line bets as other, not gambit', () => {
+    const rows = [makeRow(1, 10, new Date(2024, 0, 1), makeBetUrl(1, [[1, 0, 0, 0, 0]]))];
+    expect(computeBetShapeCounts(rows).other).toBe(1);
+  });
+
+  it('skips rows with no active bet lines and returns zeroed counts for empty input', () => {
+    expect(computeBetShapeCounts([])).toEqual({
+      gambitShaped: 0,
+      bustproofShaped: 0,
+      crazyShaped: 0,
+      tenbetShaped: 0,
+      other: 0,
+      total: 0,
+    });
   });
 });
 

--- a/src/app/analysis/__tests__/fcDataStats.test.ts
+++ b/src/app/analysis/__tests__/fcDataStats.test.ts
@@ -42,6 +42,7 @@ describe('computeTotals', () => {
       bestRound: null,
       longestWinStreak: null,
       longestLossStreak: null,
+      currentStreak: null,
       firstRound: null,
       lastRound: null,
     });
@@ -110,6 +111,51 @@ describe('computeTotals', () => {
     const totals = computeTotals(rows);
 
     expect(totals.bestRound).toBe(rows[0]);
+  });
+
+  it('reports an ongoing win streak when the most recent round won', () => {
+    // L, W, W (still winning as of the last row)
+    const rows = [0, 5, 10].map((unitsWon, i) =>
+      makeRow(i + 1, unitsWon, new Date(2024, 0, i + 1)),
+    );
+    const totals = computeTotals(rows);
+
+    expect(totals.currentStreak).toEqual({
+      type: 'win',
+      count: 2,
+      startDate: new Date(2024, 0, 2),
+      endDate: new Date(2024, 0, 3),
+    });
+  });
+
+  it('reports an ongoing bust streak when the most recent round busted', () => {
+    // W, L, L (still busting as of the last row)
+    const rows = [10, 0, 0].map((unitsWon, i) =>
+      makeRow(i + 1, unitsWon, new Date(2024, 0, i + 1)),
+    );
+    const totals = computeTotals(rows);
+
+    expect(totals.currentStreak).toEqual({
+      type: 'bust',
+      count: 2,
+      startDate: new Date(2024, 0, 2),
+      endDate: new Date(2024, 0, 3),
+    });
+  });
+
+  it('reports a current streak of 1 when the last round flips the trend', () => {
+    // W, W, L
+    const rows = [10, 5, 0].map((unitsWon, i) =>
+      makeRow(i + 1, unitsWon, new Date(2024, 0, i + 1)),
+    );
+    const totals = computeTotals(rows);
+
+    expect(totals.currentStreak).toEqual({
+      type: 'bust',
+      count: 1,
+      startDate: new Date(2024, 0, 3),
+      endDate: new Date(2024, 0, 3),
+    });
   });
 });
 

--- a/src/app/analysis/__tests__/fcDataStats.test.ts
+++ b/src/app/analysis/__tests__/fcDataStats.test.ts
@@ -4,13 +4,17 @@ import type { FcDataRow } from '../../data/fcDataCsv';
 import { wasmBetsIndicesToHash } from '../../wasmMath';
 import {
   activeBetLineCount,
+  buildShareSummary,
   classifyRoundReturn,
   computeBetShapeCounts,
   computeCumulativeSeries,
   computeMonthlyStats,
   computeReturnDistribution,
   computeRoiSeries,
+  computeRollingRoiSeries,
   computeTotals,
+  computeYearlyStats,
+  findBestAndWorstMonth,
   findMissedRoundGaps,
 } from '../fcDataStats';
 
@@ -187,6 +191,59 @@ describe('computeMonthlyStats', () => {
   });
 });
 
+describe('computeYearlyStats', () => {
+  it('buckets rows across years, sorted ascending', () => {
+    const rows = [
+      makeRow(1, 10, new Date(2023, 11, 30)),
+      makeRow(2, 20, new Date(2024, 0, 1)),
+      makeRow(3, 30, new Date(2024, 5, 2)),
+    ];
+    const years = computeYearlyStats(rows);
+
+    expect(years.map(y => y.yearKey)).toEqual(['2023', '2024']);
+    expect(years[0]!.label).toBe('2023');
+    expect(years[1]!.roundsPlayed).toBe(2);
+    expect(years[1]!.totalUnitsWon).toBe(50);
+  });
+
+  it('accumulates cumulativeRoi across years like computeMonthlyStats does across months', () => {
+    const oneLineUrl = makeBetUrl(1, [[1, 0, 0, 0, 0]]);
+    const rows = [
+      makeRow(1, 2, new Date(2023, 0, 1), oneLineUrl), // 2023: 2/1 = 2.0x
+      makeRow(2, 0, new Date(2024, 0, 1), oneLineUrl), // 2024: (2+0)/(1+1) = 1.0x cumulative
+    ];
+    const years = computeYearlyStats(rows);
+
+    expect(years[0]!.roi).toBe(2);
+    expect(years[0]!.cumulativeRoi).toBe(2);
+    expect(years[1]!.roi).toBe(0);
+    expect(years[1]!.cumulativeRoi).toBe(1);
+  });
+});
+
+describe('findBestAndWorstMonth', () => {
+  it('finds the highest and lowest totalUnitsWon months', () => {
+    const rows = [
+      makeRow(1, 5, new Date(2024, 0, 1)),
+      makeRow(2, 100, new Date(2024, 1, 1)),
+      makeRow(3, 20, new Date(2024, 2, 1)),
+    ];
+    const months = computeMonthlyStats(rows);
+    const { best, worst } = findBestAndWorstMonth(months);
+
+    expect(best?.label).toBe('Feb 2024');
+    expect(worst?.label).toBe('Jan 2024');
+  });
+
+  it('returns nulls when there are fewer than 2 months', () => {
+    const rows = [makeRow(1, 5, new Date(2024, 0, 1)), makeRow(2, 10, new Date(2024, 0, 2))];
+    const months = computeMonthlyStats(rows);
+
+    expect(findBestAndWorstMonth(months)).toEqual({ best: null, worst: null });
+    expect(findBestAndWorstMonth([])).toEqual({ best: null, worst: null });
+  });
+});
+
 describe('computeCumulativeSeries', () => {
   it('is monotonically non-decreasing and ends at the total', () => {
     const rows = [
@@ -228,6 +285,37 @@ describe('computeRoiSeries', () => {
 
   it('returns an empty series for empty input', () => {
     expect(computeRoiSeries([])).toEqual([]);
+  });
+});
+
+describe('computeRollingRoiSeries', () => {
+  it('only considers the trailing window, unlike the all-time cumulative roi', () => {
+    const oneLineUrl = makeBetUrl(1, [[1, 0, 0, 0, 0]]);
+    // Window of 2: round 3's rolling roi should drop round 1 out of the average.
+    const rows = [
+      makeRow(1, 10, new Date(2024, 0, 1), oneLineUrl), // 10/1 = 10x
+      makeRow(2, 0, new Date(2024, 0, 2), oneLineUrl), // (10+0)/(1+1) = 5x
+      makeRow(3, 2, new Date(2024, 0, 3), oneLineUrl), // window is now [round2, round3]: (0+2)/(1+1) = 1x
+    ];
+
+    const series = computeRollingRoiSeries(rows, 2);
+
+    expect(series).toEqual([
+      { round: 1, roi: 10 },
+      { round: 2, roi: 5 },
+      { round: 3, roi: 1 },
+    ]);
+  });
+
+  it('defaults to a 30-round window', () => {
+    const oneLineUrl = makeBetUrl(1, [[1, 0, 0, 0, 0]]);
+    const rows = [makeRow(1, 5, new Date(2024, 0, 1), oneLineUrl)];
+
+    expect(computeRollingRoiSeries(rows)).toEqual(computeRollingRoiSeries(rows, 30));
+  });
+
+  it('returns an empty series for empty input', () => {
+    expect(computeRollingRoiSeries([])).toEqual([]);
   });
 });
 
@@ -471,5 +559,32 @@ describe('computeMonthlyStats roi', () => {
     expect(months[0]!.cumulativeRoi).toBe(2);
     expect(months[1]!.roi).toBe(0);
     expect(months[1]!.cumulativeRoi).toBe(1);
+  });
+});
+
+describe('buildShareSummary', () => {
+  it('returns a placeholder for no rows', () => {
+    expect(buildShareSummary(computeTotals([]))).toBe('No FC Data loaded yet.');
+  });
+
+  it('includes rounds, totals, best round, and streaks', () => {
+    const rows = [10, 5, 0, 8].map((unitsWon, i) =>
+      makeRow(i + 1, unitsWon, new Date(2024, 0, i + 1)),
+    );
+    const summary = buildShareSummary(computeTotals(rows));
+
+    expect(summary).toContain('4 rounds tracked');
+    expect(summary).toContain('Total won: 23 units');
+    expect(summary).toContain('Best round: #1 (10 units)');
+    expect(summary).toContain('Current streak: 1 win (8 units)');
+    expect(summary).toContain('Longest win streak: 2 (15 units)');
+  });
+
+  it('omits streak lines that are null (e.g. an all-bust history)', () => {
+    const rows = [0, 0].map((unitsWon, i) => makeRow(i + 1, unitsWon, new Date(2024, 0, i + 1)));
+    const summary = buildShareSummary(computeTotals(rows));
+
+    expect(summary).not.toContain('Longest win streak');
+    expect(summary).toContain('Current streak: 2 busts');
   });
 });

--- a/src/app/analysis/__tests__/fcDataStats.test.ts
+++ b/src/app/analysis/__tests__/fcDataStats.test.ts
@@ -4,8 +4,10 @@ import type { FcDataRow } from '../../data/fcDataCsv';
 import { wasmBetsIndicesToHash } from '../../wasmMath';
 import {
   activeBetLineCount,
+  classifyRoundReturn,
   computeCumulativeSeries,
   computeMonthlyStats,
+  computeReturnDistribution,
   computeRoiSeries,
   computeTotals,
   findMissedRoundGaps,
@@ -224,6 +226,59 @@ describe('activeBetLineCount', () => {
 
   it('returns 0 for a URL with no bet hash', () => {
     expect(activeBetLineCount('https://neofood.club/#round=1')).toBe(0);
+  });
+});
+
+describe('classifyRoundReturn', () => {
+  const oneLineUrl = makeBetUrl(1, [[1, 0, 0, 0, 0]]);
+  const twoLineUrl = makeBetUrl(1, [
+    [1, 0, 0, 0, 0],
+    [0, 2, 0, 0, 0],
+  ]);
+
+  it('classifies a round with no units won as bust', () => {
+    expect(classifyRoundReturn(makeRow(1, 0, new Date(2024, 0, 1), oneLineUrl))).toBe('bust');
+  });
+
+  it('classifies under 1x per line as partial', () => {
+    // 1 unit won / 2 active lines = 0.5x.
+    expect(classifyRoundReturn(makeRow(1, 1, new Date(2024, 0, 1), twoLineUrl))).toBe('partial');
+  });
+
+  it('classifies 1x up to 2x per line as profit (inclusive of 1x)', () => {
+    expect(classifyRoundReturn(makeRow(1, 1, new Date(2024, 0, 1), oneLineUrl))).toBe('profit');
+  });
+
+  it('classifies 2x or more per line as double', () => {
+    expect(classifyRoundReturn(makeRow(1, 2, new Date(2024, 0, 1), oneLineUrl))).toBe('double');
+  });
+});
+
+describe('computeReturnDistribution', () => {
+  it('counts rounds into buckets and tracks the total', () => {
+    const oneLineUrl = makeBetUrl(1, [[1, 0, 0, 0, 0]]);
+    const rows = [
+      makeRow(1, 0, new Date(2024, 0, 1), oneLineUrl), // bust
+      makeRow(2, 1, new Date(2024, 0, 2), oneLineUrl), // profit (1x)
+      makeRow(3, 2, new Date(2024, 0, 3), oneLineUrl), // double
+    ];
+    expect(computeReturnDistribution(rows)).toEqual({
+      bust: 1,
+      partial: 0,
+      profit: 1,
+      double: 1,
+      total: 3,
+    });
+  });
+
+  it('returns all-zero counts for empty input', () => {
+    expect(computeReturnDistribution([])).toEqual({
+      bust: 0,
+      partial: 0,
+      profit: 0,
+      double: 0,
+      total: 0,
+    });
   });
 });
 

--- a/src/app/analysis/__tests__/fcDataStats.test.ts
+++ b/src/app/analysis/__tests__/fcDataStats.test.ts
@@ -123,6 +123,7 @@ describe('computeTotals', () => {
     expect(totals.currentStreak).toEqual({
       type: 'win',
       count: 2,
+      totalUnitsWon: 15,
       startDate: new Date(2024, 0, 2),
       endDate: new Date(2024, 0, 3),
     });
@@ -138,6 +139,7 @@ describe('computeTotals', () => {
     expect(totals.currentStreak).toEqual({
       type: 'bust',
       count: 2,
+      totalUnitsWon: 0,
       startDate: new Date(2024, 0, 2),
       endDate: new Date(2024, 0, 3),
     });
@@ -153,6 +155,7 @@ describe('computeTotals', () => {
     expect(totals.currentStreak).toEqual({
       type: 'bust',
       count: 1,
+      totalUnitsWon: 0,
       startDate: new Date(2024, 0, 3),
       endDate: new Date(2024, 0, 3),
     });

--- a/src/app/analysis/__tests__/fcDataStats.test.ts
+++ b/src/app/analysis/__tests__/fcDataStats.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest';
+
+import type { FcDataRow } from '../../data/fcDataCsv';
+import {
+  computeCumulativeSeries,
+  computeDayOfWeekStats,
+  computeMonthlyStats,
+  computeTotals,
+  findMissedRoundGaps,
+} from '../fcDataStats';
+
+function makeRow(round: number, unitsWon: number, date: Date): FcDataRow {
+  return {
+    date,
+    rawDate: date.toISOString(),
+    round,
+    unitsWon,
+    url: `https://neofood.club/#round=${round}`,
+  };
+}
+
+describe('computeTotals', () => {
+  it('handles empty input without NaN', () => {
+    const totals = computeTotals([]);
+    expect(totals).toEqual({
+      roundsRecorded: 0,
+      totalUnitsWon: 0,
+      averageUnitsPerRound: 0,
+      winRate: 0,
+      bestRound: null,
+      longestWinStreak: 0,
+      longestLossStreak: 0,
+      firstRound: null,
+      lastRound: null,
+    });
+  });
+
+  it('handles an all-zero (never won) history', () => {
+    const rows = [
+      makeRow(1, 0, new Date(2024, 0, 1)),
+      makeRow(2, 0, new Date(2024, 0, 2)),
+      makeRow(3, 0, new Date(2024, 0, 3)),
+    ];
+    const totals = computeTotals(rows);
+
+    expect(totals.winRate).toBe(0);
+    expect(totals.longestWinStreak).toBe(0);
+    expect(totals.longestLossStreak).toBe(3);
+    expect(totals.bestRound).toBe(rows[0]);
+  });
+
+  it('handles an all-win history', () => {
+    const rows = [
+      makeRow(1, 10, new Date(2024, 0, 1)),
+      makeRow(2, 5, new Date(2024, 0, 2)),
+      makeRow(3, 20, new Date(2024, 0, 3)),
+    ];
+    const totals = computeTotals(rows);
+
+    expect(totals.winRate).toBe(1);
+    expect(totals.longestLossStreak).toBe(0);
+    expect(totals.longestWinStreak).toBe(3);
+  });
+
+  it('finds the correct longest streak with alternating results', () => {
+    // W, W, L, W, W, W, L
+    const rows = [10, 5, 0, 3, 8, 12, 0].map((unitsWon, i) =>
+      makeRow(i + 1, unitsWon, new Date(2024, 0, i + 1)),
+    );
+    const totals = computeTotals(rows);
+
+    expect(totals.longestWinStreak).toBe(3);
+    expect(totals.longestLossStreak).toBe(1);
+  });
+
+  it('breaks a tie for bestRound by taking the first occurrence', () => {
+    const rows = [makeRow(1, 50, new Date(2024, 0, 1)), makeRow(2, 50, new Date(2024, 0, 2))];
+    const totals = computeTotals(rows);
+
+    expect(totals.bestRound).toBe(rows[0]);
+  });
+});
+
+describe('computeMonthlyStats', () => {
+  it('buckets rows across a year boundary into distinct months', () => {
+    const rows = [
+      makeRow(1, 10, new Date(2023, 11, 30)),
+      makeRow(2, 20, new Date(2024, 0, 1)),
+      makeRow(3, 30, new Date(2024, 0, 2)),
+    ];
+    const months = computeMonthlyStats(rows);
+
+    expect(months.map(m => m.monthKey)).toEqual(['2023-12', '2024-01']);
+    expect(months[0]!.roundsPlayed).toBe(1);
+    expect(months[1]!.roundsPlayed).toBe(2);
+    expect(months[1]!.totalUnitsWon).toBe(50);
+  });
+
+  it('produces one entry for a single month', () => {
+    const rows = [makeRow(1, 5, new Date(2024, 3, 1)), makeRow(2, 15, new Date(2024, 3, 5))];
+    const months = computeMonthlyStats(rows);
+
+    expect(months).toHaveLength(1);
+    expect(months[0]!.label).toBe('Apr 2024');
+    expect(months[0]!.averageUnitsPerRound).toBe(10);
+  });
+});
+
+describe('computeCumulativeSeries', () => {
+  it('is monotonically non-decreasing and ends at the total', () => {
+    const rows = [
+      makeRow(1, 5, new Date(2024, 0, 1)),
+      makeRow(2, 0, new Date(2024, 0, 2)),
+      makeRow(3, 15, new Date(2024, 0, 3)),
+    ];
+    const series = computeCumulativeSeries(rows);
+
+    expect(series).toHaveLength(3);
+    for (let i = 1; i < series.length; i++) {
+      expect(series[i]!.cumulative).toBeGreaterThanOrEqual(series[i - 1]!.cumulative);
+    }
+    expect(series[series.length - 1]!.cumulative).toBe(20);
+  });
+});
+
+describe('findMissedRoundGaps', () => {
+  it('returns no gaps for consecutive rounds', () => {
+    const rows = [1, 2, 3].map(round => makeRow(round, 0, new Date(2024, 0, round)));
+    expect(findMissedRoundGaps(rows)).toEqual([]);
+  });
+
+  it('detects a single gap', () => {
+    const rows = [makeRow(1, 0, new Date(2024, 0, 1)), makeRow(5, 0, new Date(2024, 0, 5))];
+    expect(findMissedRoundGaps(rows)).toEqual([{ afterRound: 1, beforeRound: 5, missingCount: 3 }]);
+  });
+
+  it('detects multiple gaps in order', () => {
+    const rows = [1, 3, 4, 10].map(round => makeRow(round, 0, new Date(2024, 0, round)));
+    expect(findMissedRoundGaps(rows)).toEqual([
+      { afterRound: 1, beforeRound: 3, missingCount: 1 },
+      { afterRound: 4, beforeRound: 10, missingCount: 5 },
+    ]);
+  });
+
+  it('returns no gaps for a single-row input', () => {
+    expect(findMissedRoundGaps([makeRow(1, 0, new Date(2024, 0, 1))])).toEqual([]);
+    expect(findMissedRoundGaps([])).toEqual([]);
+  });
+});
+
+describe('computeDayOfWeekStats', () => {
+  it('always returns 7 entries in Sun-Sat order, even for empty input', () => {
+    const stats = computeDayOfWeekStats([]);
+    expect(stats).toHaveLength(7);
+    expect(stats.map(s => s.label)).toEqual(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']);
+    expect(stats.every(s => s.roundsPlayed === 0 && s.totalUnitsWon === 0)).toBe(true);
+  });
+
+  it('buckets rows by day of week', () => {
+    // 2024-01-01 is a Monday.
+    const rows = [
+      makeRow(1, 10, new Date(2024, 0, 1)), // Mon
+      makeRow(2, 5, new Date(2024, 0, 8)), // Mon
+      makeRow(3, 20, new Date(2024, 0, 2)), // Tue
+    ];
+    const stats = computeDayOfWeekStats(rows);
+    const monday = stats.find(s => s.label === 'Mon')!;
+    const tuesday = stats.find(s => s.label === 'Tue')!;
+
+    expect(monday.roundsPlayed).toBe(2);
+    expect(monday.totalUnitsWon).toBe(15);
+    expect(monday.averageUnitsPerRound).toBe(7.5);
+    expect(tuesday.roundsPlayed).toBe(1);
+    expect(tuesday.totalUnitsWon).toBe(20);
+  });
+});

--- a/src/app/analysis/__tests__/fcDataStats.test.ts
+++ b/src/app/analysis/__tests__/fcDataStats.test.ts
@@ -1,22 +1,30 @@
 import { describe, expect, it } from 'vitest';
 
 import type { FcDataRow } from '../../data/fcDataCsv';
+import { wasmBetsIndicesToHash } from '../../wasmMath';
 import {
+  activeBetLineCount,
   computeCumulativeSeries,
-  computeDayOfWeekStats,
   computeMonthlyStats,
   computeTotals,
   findMissedRoundGaps,
 } from '../fcDataStats';
 
-function makeRow(round: number, unitsWon: number, date: Date): FcDataRow {
+function makeRow(round: number, unitsWon: number, date: Date, url?: string): FcDataRow {
   return {
     date,
     rawDate: date.toISOString(),
     round,
     unitsWon,
-    url: `https://neofood.club/#round=${round}`,
+    url: url ?? `https://neofood.club/#round=${round}`,
   };
+}
+
+/** Builds a NeoFoodClub bet URL encoding the given bet lines (each a 5-element arena pick array). */
+function makeBetUrl(round: number, lines: number[][]): string {
+  const flat = lines.flat();
+  const hash = wasmBetsIndicesToHash(flat);
+  return `https://neofood.club/#round=${round}&b=${hash}`;
 }
 
 describe('computeTotals', () => {
@@ -28,8 +36,8 @@ describe('computeTotals', () => {
       averageUnitsPerRound: 0,
       winRate: 0,
       bestRound: null,
-      longestWinStreak: 0,
-      longestLossStreak: 0,
+      longestWinStreak: null,
+      longestLossStreak: null,
       firstRound: null,
       lastRound: null,
     });
@@ -44,8 +52,12 @@ describe('computeTotals', () => {
     const totals = computeTotals(rows);
 
     expect(totals.winRate).toBe(0);
-    expect(totals.longestWinStreak).toBe(0);
-    expect(totals.longestLossStreak).toBe(3);
+    expect(totals.longestWinStreak).toBeNull();
+    expect(totals.longestLossStreak).toEqual({
+      count: 3,
+      startDate: new Date(2024, 0, 1),
+      endDate: new Date(2024, 0, 3),
+    });
     expect(totals.bestRound).toBe(rows[0]);
   });
 
@@ -58,8 +70,13 @@ describe('computeTotals', () => {
     const totals = computeTotals(rows);
 
     expect(totals.winRate).toBe(1);
-    expect(totals.longestLossStreak).toBe(0);
-    expect(totals.longestWinStreak).toBe(3);
+    expect(totals.longestLossStreak).toBeNull();
+    expect(totals.longestWinStreak).toEqual({
+      count: 3,
+      totalUnitsWon: 35,
+      startDate: new Date(2024, 0, 1),
+      endDate: new Date(2024, 0, 3),
+    });
   });
 
   it('finds the correct longest streak with alternating results', () => {
@@ -69,8 +86,19 @@ describe('computeTotals', () => {
     );
     const totals = computeTotals(rows);
 
-    expect(totals.longestWinStreak).toBe(3);
-    expect(totals.longestLossStreak).toBe(1);
+    // The longest streak is the run of 3 wins (3, 8, 12), not the earlier run of 2 (10, 5),
+    // spanning rows 4-6 (Jan 4-6).
+    expect(totals.longestWinStreak).toEqual({
+      count: 3,
+      totalUnitsWon: 23,
+      startDate: new Date(2024, 0, 4),
+      endDate: new Date(2024, 0, 6),
+    });
+    expect(totals.longestLossStreak).toEqual({
+      count: 1,
+      startDate: new Date(2024, 0, 3),
+      endDate: new Date(2024, 0, 3),
+    });
   });
 
   it('breaks a tie for bestRound by taking the first occurrence', () => {
@@ -148,29 +176,67 @@ describe('findMissedRoundGaps', () => {
   });
 });
 
-describe('computeDayOfWeekStats', () => {
-  it('always returns 7 entries in Sun-Sat order, even for empty input', () => {
-    const stats = computeDayOfWeekStats([]);
-    expect(stats).toHaveLength(7);
-    expect(stats.map(s => s.label)).toEqual(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']);
-    expect(stats.every(s => s.roundsPlayed === 0 && s.totalUnitsWon === 0)).toBe(true);
+describe('activeBetLineCount', () => {
+  it('counts only lines with at least one non-zero pirate pick', () => {
+    // Line 1 picks a pirate in arena 0; line 2 picks a pirate in arena 1; both active.
+    const url = makeBetUrl(1, [
+      [1, 0, 0, 0, 0],
+      [0, 2, 0, 0, 0],
+    ]);
+    expect(activeBetLineCount(url)).toBe(2);
   });
 
-  it('buckets rows by day of week', () => {
-    // 2024-01-01 is a Monday.
-    const rows = [
-      makeRow(1, 10, new Date(2024, 0, 1)), // Mon
-      makeRow(2, 5, new Date(2024, 0, 8)), // Mon
-      makeRow(3, 20, new Date(2024, 0, 2)), // Tue
-    ];
-    const stats = computeDayOfWeekStats(rows);
-    const monday = stats.find(s => s.label === 'Mon')!;
-    const tuesday = stats.find(s => s.label === 'Tue')!;
+  it('does not count all-zero lines', () => {
+    const url = makeBetUrl(1, [
+      [1, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0],
+    ]);
+    expect(activeBetLineCount(url)).toBe(1);
+  });
 
-    expect(monday.roundsPlayed).toBe(2);
-    expect(monday.totalUnitsWon).toBe(15);
-    expect(monday.averageUnitsPerRound).toBe(7.5);
-    expect(tuesday.roundsPlayed).toBe(1);
-    expect(tuesday.totalUnitsWon).toBe(20);
+  it('returns 0 for a URL with no bet hash', () => {
+    expect(activeBetLineCount('https://neofood.club/#round=1')).toBe(0);
+  });
+});
+
+describe('computeMonthlyStats roi', () => {
+  it('divides total units won by total active bet lines for the month', () => {
+    const url1 = makeBetUrl(1, [
+      [1, 0, 0, 0, 0],
+      [0, 2, 0, 0, 0],
+    ]); // 2 active lines
+    const url2 = makeBetUrl(2, [[3, 0, 0, 0, 0]]); // 1 active line
+    const rows = [
+      makeRow(1, 6, new Date(2024, 0, 1), url1),
+      makeRow(2, 3, new Date(2024, 0, 2), url2),
+    ];
+    const months = computeMonthlyStats(rows);
+
+    // (6 + 3) units won / (2 + 1) active lines = 3.0x
+    expect(months[0]!.roi).toBe(3);
+  });
+
+  it('is 0 when there are no active bet lines to avoid dividing by zero', () => {
+    const rows = [makeRow(1, 5, new Date(2024, 0, 1), 'https://neofood.club/#round=1')];
+    const months = computeMonthlyStats(rows);
+
+    expect(months[0]!.roi).toBe(0);
+  });
+
+  it('accumulates roi across months in cumulativeRoi', () => {
+    const oneLineUrl = makeBetUrl(1, [[1, 0, 0, 0, 0]]);
+    const rows = [
+      // January: 2 units won / 1 line = 2.0x that month.
+      makeRow(1, 2, new Date(2024, 0, 1), oneLineUrl),
+      // February: 0 units won / 1 line = 0.0x that month, but cumulative
+      // stays (2 + 0) / (1 + 1) = 1.0x.
+      makeRow(2, 0, new Date(2024, 1, 1), oneLineUrl),
+    ];
+    const months = computeMonthlyStats(rows);
+
+    expect(months[0]!.roi).toBe(2);
+    expect(months[0]!.cumulativeRoi).toBe(2);
+    expect(months[1]!.roi).toBe(0);
+    expect(months[1]!.cumulativeRoi).toBe(1);
   });
 });

--- a/src/app/analysis/fcDataAdvancedStats.ts
+++ b/src/app/analysis/fcDataAdvancedStats.ts
@@ -1,7 +1,8 @@
 import type { BacktestRound } from '../backtest/types';
 import { ARENA_NAMES, PIRATE_NAMES } from '../constants';
 import type { FcDataRow } from '../data/fcDataCsv';
-import { parseBetUrl } from '../util';
+
+import { decodeActiveLines } from './fcDataStats';
 
 export interface FcDataPirateExposure {
   pirateId: number;
@@ -22,15 +23,6 @@ export interface FcDataArenaUsage {
   name: string;
   /** Share of active bet lines (across matched rounds) that included a pick in this arena, 0..1. */
   lineParticipationRate: number;
-}
-
-export interface FcDataBetShapeCounts {
-  /** Every active line's picks are a subset of one fixed 5-pirate combo (see `classifyBetShape`). */
-  gambitShaped: number;
-  /** One (arena, pirate) pair is held fixed across every active line. */
-  tenbetShaped: number;
-  other: number;
-  total: number;
 }
 
 export interface FcDataAdvancedFingerprint {
@@ -55,61 +47,8 @@ export interface FcDataAdvancedStats {
   pirateExposure: FcDataPirateExposure[];
   /** In arena order (Shipwreck..Harpoon). */
   arenaUsage: FcDataArenaUsage[];
-  betShapes: FcDataBetShapeCounts;
   fingerprint: FcDataAdvancedFingerprint;
   favoriteAnchorPirate: FcDataFavoriteAnchor | null;
-}
-
-/** One entry per active bet line: 5 positions (1-4, or 0 for "no pick"), one per arena. */
-function decodeActiveLines(url: string): number[][] {
-  const hashIndex = url.indexOf('#');
-  const fragment = hashIndex === -1 ? url : url.slice(hashIndex + 1);
-  const { bets } = parseBetUrl(fragment);
-
-  const lines: number[][] = [];
-  for (const positions of bets.values()) {
-    if (positions.some(position => position > 0)) {
-      lines.push(positions);
-    }
-  }
-  return lines;
-}
-
-/**
- * Classifies a round's decoded bet lines by structure:
- * - `gambit`: every arena has at most one distinct nonzero position across
- *   all lines (every line is a subset of one fixed 5-pirate combo).
- * - `tenbet`: some arena holds one fixed nonzero position across every
- *   line (one "anchor" pirate present in every line), while other arenas vary.
- * - `other`: neither shape, or too few lines to tell (single-line bets).
- */
-function classifyBetShape(lines: number[][]): 'gambit' | 'tenbet' | 'other' {
-  if (lines.length <= 1) {
-    return 'other';
-  }
-
-  let isGambit = true;
-  for (let arena = 0; arena < 5; arena++) {
-    const positions = new Set(
-      lines.map(line => line[arena]).filter((p): p is number => !!p && p > 0),
-    );
-    if (positions.size > 1) {
-      isGambit = false;
-      break;
-    }
-  }
-  if (isGambit) {
-    return 'gambit';
-  }
-
-  for (let arena = 0; arena < 5; arena++) {
-    const first = lines[0]![arena]!;
-    if (first > 0 && lines.every(line => line[arena] === first)) {
-      return 'tenbet';
-    }
-  }
-
-  return 'other';
 }
 
 interface PirateAggregate {
@@ -125,7 +64,6 @@ export function computeAdvancedStats(
 ): FcDataAdvancedStats {
   const pirateAgg = new Map<number, PirateAggregate>();
   const arenaLineCount = [0, 0, 0, 0, 0];
-  const betShapes: FcDataBetShapeCounts = { gambitShaped: 0, tenbetShaped: 0, other: 0, total: 0 };
 
   let totalActiveLines = 0;
   let totalPirateLinePicks = 0;
@@ -150,12 +88,6 @@ export function computeAdvancedStats(
     if (lines.length === 10) {
       tenLineRounds += 1;
     }
-
-    const shape = classifyBetShape(lines);
-    betShapes[
-      shape === 'gambit' ? 'gambitShaped' : shape === 'tenbet' ? 'tenbetShaped' : 'other'
-    ] += 1;
-    betShapes.total += 1;
 
     const pirateLineCounts = new Map<number, number>();
 
@@ -242,7 +174,6 @@ export function computeAdvancedStats(
   return {
     pirateExposure,
     arenaUsage,
-    betShapes,
     fingerprint: {
       matchedRounds,
       unmatchedRounds,

--- a/src/app/analysis/fcDataAdvancedStats.ts
+++ b/src/app/analysis/fcDataAdvancedStats.ts
@@ -1,0 +1,256 @@
+import type { BacktestRound } from '../backtest/types';
+import { ARENA_NAMES, PIRATE_NAMES } from '../constants';
+import type { FcDataRow } from '../data/fcDataCsv';
+import { parseBetUrl } from '../util';
+
+export interface FcDataPirateExposure {
+  pirateId: number;
+  name: string;
+  roundsIncluded: number;
+  /** roundsIncluded / total matched rounds, 0..1. */
+  roundParticipationRate: number;
+  /** Average number of active lines (within a round) that include this pirate, among rounds where included. */
+  averageLinesWhenIncluded: number;
+  /** Average unitsWon in rounds where this pirate was included (co-occurrence proxy, not true per-pirate attribution). */
+  averageUnitsWonWhenIncluded: number;
+  /** Rounds where this pirate appeared in literally every active line that round. */
+  anchorRoundCount: number;
+}
+
+export interface FcDataArenaUsage {
+  arenaIndex: number;
+  name: string;
+  /** Share of active bet lines (across matched rounds) that included a pick in this arena, 0..1. */
+  lineParticipationRate: number;
+}
+
+export interface FcDataBetShapeCounts {
+  /** Every active line's picks are a subset of one fixed 5-pirate combo (see `classifyBetShape`). */
+  gambitShaped: number;
+  /** One (arena, pirate) pair is held fixed across every active line. */
+  tenbetShaped: number;
+  other: number;
+  total: number;
+}
+
+export interface FcDataAdvancedFingerprint {
+  matchedRounds: number;
+  unmatchedRounds: number;
+  averagePiratesPerLine: number;
+  averageUniquePiratesPerRound: number;
+  /** Share of matched rounds with exactly 10 active bet lines, 0..1. */
+  tenLineShare: number;
+}
+
+export interface FcDataFavoriteAnchor {
+  pirateId: number;
+  name: string;
+  anchorRoundCount: number;
+  /** anchorRoundCount / matched rounds, 0..1. */
+  share: number;
+}
+
+export interface FcDataAdvancedStats {
+  /** Sorted by roundParticipationRate descending. */
+  pirateExposure: FcDataPirateExposure[];
+  /** In arena order (Shipwreck..Harpoon). */
+  arenaUsage: FcDataArenaUsage[];
+  betShapes: FcDataBetShapeCounts;
+  fingerprint: FcDataAdvancedFingerprint;
+  favoriteAnchorPirate: FcDataFavoriteAnchor | null;
+}
+
+/** One entry per active bet line: 5 positions (1-4, or 0 for "no pick"), one per arena. */
+function decodeActiveLines(url: string): number[][] {
+  const hashIndex = url.indexOf('#');
+  const fragment = hashIndex === -1 ? url : url.slice(hashIndex + 1);
+  const { bets } = parseBetUrl(fragment);
+
+  const lines: number[][] = [];
+  for (const positions of bets.values()) {
+    if (positions.some(position => position > 0)) {
+      lines.push(positions);
+    }
+  }
+  return lines;
+}
+
+/**
+ * Classifies a round's decoded bet lines by structure:
+ * - `gambit`: every arena has at most one distinct nonzero position across
+ *   all lines (every line is a subset of one fixed 5-pirate combo).
+ * - `tenbet`: some arena holds one fixed nonzero position across every
+ *   line (one "anchor" pirate present in every line), while other arenas vary.
+ * - `other`: neither shape, or too few lines to tell (single-line bets).
+ */
+function classifyBetShape(lines: number[][]): 'gambit' | 'tenbet' | 'other' {
+  if (lines.length <= 1) {
+    return 'other';
+  }
+
+  let isGambit = true;
+  for (let arena = 0; arena < 5; arena++) {
+    const positions = new Set(
+      lines.map(line => line[arena]).filter((p): p is number => !!p && p > 0),
+    );
+    if (positions.size > 1) {
+      isGambit = false;
+      break;
+    }
+  }
+  if (isGambit) {
+    return 'gambit';
+  }
+
+  for (let arena = 0; arena < 5; arena++) {
+    const first = lines[0]![arena]!;
+    if (first > 0 && lines.every(line => line[arena] === first)) {
+      return 'tenbet';
+    }
+  }
+
+  return 'other';
+}
+
+interface PirateAggregate {
+  roundsIncluded: number;
+  lineSum: number;
+  unitsWonSum: number;
+  anchorRoundCount: number;
+}
+
+export function computeAdvancedStats(
+  rows: FcDataRow[],
+  roundsByNumber: Map<number, BacktestRound>,
+): FcDataAdvancedStats {
+  const pirateAgg = new Map<number, PirateAggregate>();
+  const arenaLineCount = [0, 0, 0, 0, 0];
+  const betShapes: FcDataBetShapeCounts = { gambitShaped: 0, tenbetShaped: 0, other: 0, total: 0 };
+
+  let totalActiveLines = 0;
+  let totalPirateLinePicks = 0;
+  let uniquePiratesPerRoundSum = 0;
+  let tenLineRounds = 0;
+  let matchedRounds = 0;
+  let unmatchedRounds = 0;
+
+  for (const row of rows) {
+    const round = roundsByNumber.get(row.round);
+    if (!round) {
+      unmatchedRounds += 1;
+      continue;
+    }
+    matchedRounds += 1;
+
+    const lines = decodeActiveLines(row.url);
+    if (lines.length === 0) {
+      continue;
+    }
+
+    if (lines.length === 10) {
+      tenLineRounds += 1;
+    }
+
+    const shape = classifyBetShape(lines);
+    betShapes[
+      shape === 'gambit' ? 'gambitShaped' : shape === 'tenbet' ? 'tenbetShaped' : 'other'
+    ] += 1;
+    betShapes.total += 1;
+
+    const pirateLineCounts = new Map<number, number>();
+
+    for (const line of lines) {
+      totalActiveLines += 1;
+      for (let arena = 0; arena < 5; arena++) {
+        const position = line[arena] ?? 0;
+        if (position <= 0) {
+          continue;
+        }
+        arenaLineCount[arena] = (arenaLineCount[arena] ?? 0) + 1;
+        totalPirateLinePicks += 1;
+
+        const pirateId = round.pirates[arena]?.[position - 1];
+        if (!pirateId) {
+          continue;
+        }
+        pirateLineCounts.set(pirateId, (pirateLineCounts.get(pirateId) ?? 0) + 1);
+      }
+    }
+
+    uniquePiratesPerRoundSum += pirateLineCounts.size;
+
+    let anchorPirateId: number | null = null;
+    for (const [pirateId, count] of pirateLineCounts) {
+      if (count === lines.length) {
+        anchorPirateId = pirateId;
+        break;
+      }
+    }
+
+    for (const [pirateId, lineCount] of pirateLineCounts) {
+      const agg = pirateAgg.get(pirateId) ?? {
+        roundsIncluded: 0,
+        lineSum: 0,
+        unitsWonSum: 0,
+        anchorRoundCount: 0,
+      };
+      agg.roundsIncluded += 1;
+      agg.lineSum += lineCount;
+      agg.unitsWonSum += row.unitsWon;
+      if (pirateId === anchorPirateId) {
+        agg.anchorRoundCount += 1;
+      }
+      pirateAgg.set(pirateId, agg);
+    }
+  }
+
+  const pirateExposure: FcDataPirateExposure[] = Array.from(pirateAgg.entries())
+    .map(([pirateId, agg]) => ({
+      pirateId,
+      name: PIRATE_NAMES.get(pirateId) ?? `Pirate ${pirateId}`,
+      roundsIncluded: agg.roundsIncluded,
+      roundParticipationRate: matchedRounds > 0 ? agg.roundsIncluded / matchedRounds : 0,
+      averageLinesWhenIncluded: agg.roundsIncluded > 0 ? agg.lineSum / agg.roundsIncluded : 0,
+      averageUnitsWonWhenIncluded:
+        agg.roundsIncluded > 0 ? agg.unitsWonSum / agg.roundsIncluded : 0,
+      anchorRoundCount: agg.anchorRoundCount,
+    }))
+    .sort((a, b) => b.roundParticipationRate - a.roundParticipationRate);
+
+  const arenaUsage: FcDataArenaUsage[] = ARENA_NAMES.map((name, arenaIndex) => ({
+    arenaIndex,
+    name,
+    lineParticipationRate:
+      totalActiveLines > 0 ? (arenaLineCount[arenaIndex] ?? 0) / totalActiveLines : 0,
+  }));
+
+  let favoriteAnchorPirate: FcDataFavoriteAnchor | null = null;
+  for (const pirate of pirateExposure) {
+    if (pirate.anchorRoundCount === 0) {
+      continue;
+    }
+    if (!favoriteAnchorPirate || pirate.anchorRoundCount > favoriteAnchorPirate.anchorRoundCount) {
+      favoriteAnchorPirate = {
+        pirateId: pirate.pirateId,
+        name: pirate.name,
+        anchorRoundCount: pirate.anchorRoundCount,
+        share: matchedRounds > 0 ? pirate.anchorRoundCount / matchedRounds : 0,
+      };
+    }
+  }
+
+  return {
+    pirateExposure,
+    arenaUsage,
+    betShapes,
+    fingerprint: {
+      matchedRounds,
+      unmatchedRounds,
+      averagePiratesPerLine: totalActiveLines > 0 ? totalPirateLinePicks / totalActiveLines : 0,
+      averageUniquePiratesPerRound:
+        matchedRounds > 0 ? uniquePiratesPerRoundSum / matchedRounds : 0,
+      tenLineShare: matchedRounds > 0 ? tenLineRounds / matchedRounds : 0,
+    },
+    favoriteAnchorPirate,
+  };
+}

--- a/src/app/analysis/fcDataAdvancedStats.ts
+++ b/src/app/analysis/fcDataAdvancedStats.ts
@@ -2,7 +2,7 @@ import type { BacktestRound } from '../backtest/types';
 import { ARENA_NAMES, PIRATE_NAMES } from '../constants';
 import type { FcDataRow } from '../data/fcDataCsv';
 
-import { decodeActiveLines } from './fcDataStats';
+import { decodeActiveLines, type FcDataMissedRoundGap } from './fcDataStats';
 
 export interface FcDataPirateExposure {
   pirateId: number;
@@ -30,8 +30,6 @@ export interface FcDataAdvancedFingerprint {
   unmatchedRounds: number;
   averagePiratesPerLine: number;
   averageUniquePiratesPerRound: number;
-  /** Share of matched rounds with exactly 10 active bet lines, 0..1. */
-  tenLineShare: number;
 }
 
 export interface FcDataFavoriteAnchor {
@@ -68,7 +66,6 @@ export function computeAdvancedStats(
   let totalActiveLines = 0;
   let totalPirateLinePicks = 0;
   let uniquePiratesPerRoundSum = 0;
-  let tenLineRounds = 0;
   let matchedRounds = 0;
   let unmatchedRounds = 0;
 
@@ -83,10 +80,6 @@ export function computeAdvancedStats(
     const lines = decodeActiveLines(row.url);
     if (lines.length === 0) {
       continue;
-    }
-
-    if (lines.length === 10) {
-      tenLineRounds += 1;
     }
 
     const pirateLineCounts = new Map<number, number>();
@@ -180,8 +173,49 @@ export function computeAdvancedStats(
       averagePiratesPerLine: totalActiveLines > 0 ? totalPirateLinePicks / totalActiveLines : 0,
       averageUniquePiratesPerRound:
         matchedRounds > 0 ? uniquePiratesPerRoundSum / matchedRounds : 0,
-      tenLineShare: matchedRounds > 0 ? tenLineRounds / matchedRounds : 0,
     },
     favoriteAnchorPirate,
   };
+}
+
+/**
+ * Like `findMissedRoundGaps`, but cross-references the round-history feed so
+ * a gap in round *numbers* (e.g. a maintenance period where NeoFoodClub
+ * simply didn't run those rounds) isn't reported as a round the user forgot
+ * to bet on. Only rounds that actually exist in `roundsByNumber` count
+ * towards a gap.
+ */
+export function findMissedRoundGapsFromFeed(
+  rows: FcDataRow[],
+  roundsByNumber: Map<number, BacktestRound>,
+): FcDataMissedRoundGap[] {
+  if (rows.length < 2) {
+    return [];
+  }
+
+  const csvRounds = new Set(rows.map(row => row.round));
+  const minRound = rows[0]!.round;
+  const maxRound = rows[rows.length - 1]!.round;
+
+  const gaps: FcDataMissedRoundGap[] = [];
+  let lastSeenRound = minRound;
+  let missingCount = 0;
+
+  for (let round = minRound + 1; round <= maxRound; round++) {
+    if (csvRounds.has(round)) {
+      if (missingCount > 0) {
+        gaps.push({ afterRound: lastSeenRound, beforeRound: round, missingCount });
+        missingCount = 0;
+      }
+      lastSeenRound = round;
+      continue;
+    }
+    if (roundsByNumber.has(round)) {
+      missingCount += 1;
+    }
+    // Round doesn't appear in the feed at all - it never happened, so it
+    // doesn't count as a miss and doesn't break up a run of real misses.
+  }
+
+  return gaps;
 }

--- a/src/app/analysis/fcDataStats.ts
+++ b/src/app/analysis/fcDataStats.ts
@@ -43,24 +43,39 @@ export interface FcDataTotals {
   lastRound: FcDataRow | null;
 }
 
-export interface FcDataMonthStats {
-  /** e.g. "2024-04" - sortable, stable key. */
-  monthKey: string;
-  /** e.g. "Apr 2024". */
-  label: string;
+interface FcDataPeriodStats {
   roundsPlayed: number;
   totalUnitsWon: number;
   averageUnitsPerRound: number;
   winRate: number;
   bestRound: FcDataRow | null;
   /**
-   * totalUnitsWon / total active bet lines that month (not real NP wagered -
-   * there's no bet-amount data in the CSV, just a per-line proxy). 1.0 means
-   * each bet line broke even on average.
+   * totalUnitsWon / total active bet lines in the period (not real NP
+   * wagered - there's no bet-amount data in the CSV, just a per-line proxy).
+   * 1.0 means each bet line broke even on average.
    */
   roi: number;
-  /** Same as `roi`, but accumulated across every month up to and including this one. */
+  /** Same as `roi`, but accumulated across every period up to and including this one. */
   cumulativeRoi: number;
+}
+
+export interface FcDataMonthStats extends FcDataPeriodStats {
+  /** e.g. "2024-04" - sortable, stable key. */
+  monthKey: string;
+  /** e.g. "Apr 2024". */
+  label: string;
+}
+
+export interface FcDataYearStats extends FcDataPeriodStats {
+  /** e.g. "2024" - sortable, stable key, same as `label`. */
+  yearKey: string;
+  label: string;
+}
+
+export interface FcDataMonthHighlight {
+  /** Null when there's fewer than 2 months of history (best/worst would be trivial). */
+  best: FcDataMonthStats | null;
+  worst: FcDataMonthStats | null;
 }
 
 export interface FcDataCumulativePoint {
@@ -369,52 +384,97 @@ export function computeTotals(rows: FcDataRow[]): FcDataTotals {
   };
 }
 
-export function computeMonthlyStats(rows: FcDataRow[]): FcDataMonthStats[] {
-  const byMonth = new Map<string, FcDataRow[]>();
+interface FcDataPeriodBucket {
+  key: string;
+  sampleDate: Date;
+  stats: FcDataPeriodStats;
+}
+
+/** Buckets rows by `format(row.date, periodFormat)` and computes the same per-period stats used for both months and years. */
+function computePeriodStats(rows: FcDataRow[], periodFormat: string): FcDataPeriodBucket[] {
+  const byPeriod = new Map<string, FcDataRow[]>();
 
   for (const row of rows) {
-    const monthKey = format(row.date, 'yyyy-MM');
-    const bucket = byMonth.get(monthKey);
+    const key = format(row.date, periodFormat);
+    const bucket = byPeriod.get(key);
     if (bucket) {
       bucket.push(row);
     } else {
-      byMonth.set(monthKey, [row]);
+      byPeriod.set(key, [row]);
     }
   }
 
   let cumulativeUnitsWon = 0;
   let cumulativeBetLines = 0;
 
-  return Array.from(byMonth.entries())
+  return Array.from(byPeriod.entries())
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([monthKey, monthRows]) => {
-      const totalUnitsWon = monthRows.reduce((sum, row) => sum + row.unitsWon, 0);
-      const winningRounds = monthRows.filter(row => row.unitsWon > 0).length;
+    .map(([key, periodRows]) => {
+      const totalUnitsWon = periodRows.reduce((sum, row) => sum + row.unitsWon, 0);
+      const winningRounds = periodRows.filter(row => row.unitsWon > 0).length;
 
-      let bestRound = monthRows[0]!;
-      for (const row of monthRows) {
+      let bestRound = periodRows[0]!;
+      for (const row of periodRows) {
         if (row.unitsWon > bestRound.unitsWon) {
           bestRound = row;
         }
       }
 
-      const totalBetLines = monthRows.reduce((sum, row) => sum + activeBetLineCount(row.url), 0);
+      const totalBetLines = periodRows.reduce((sum, row) => sum + activeBetLineCount(row.url), 0);
 
       cumulativeUnitsWon += totalUnitsWon;
       cumulativeBetLines += totalBetLines;
 
       return {
-        monthKey,
-        label: format(monthRows[0]!.date, 'MMM yyyy'),
-        roundsPlayed: monthRows.length,
-        totalUnitsWon,
-        averageUnitsPerRound: totalUnitsWon / monthRows.length,
-        winRate: winningRounds / monthRows.length,
-        bestRound,
-        roi: totalBetLines > 0 ? totalUnitsWon / totalBetLines : 0,
-        cumulativeRoi: cumulativeBetLines > 0 ? cumulativeUnitsWon / cumulativeBetLines : 0,
+        key,
+        sampleDate: periodRows[0]!.date,
+        stats: {
+          roundsPlayed: periodRows.length,
+          totalUnitsWon,
+          averageUnitsPerRound: totalUnitsWon / periodRows.length,
+          winRate: winningRounds / periodRows.length,
+          bestRound,
+          roi: totalBetLines > 0 ? totalUnitsWon / totalBetLines : 0,
+          cumulativeRoi: cumulativeBetLines > 0 ? cumulativeUnitsWon / cumulativeBetLines : 0,
+        },
       };
     });
+}
+
+export function computeMonthlyStats(rows: FcDataRow[]): FcDataMonthStats[] {
+  return computePeriodStats(rows, 'yyyy-MM').map(({ key, sampleDate, stats }) => ({
+    monthKey: key,
+    label: format(sampleDate, 'MMM yyyy'),
+    ...stats,
+  }));
+}
+
+export function computeYearlyStats(rows: FcDataRow[]): FcDataYearStats[] {
+  return computePeriodStats(rows, 'yyyy').map(({ key, stats }) => ({
+    yearKey: key,
+    label: key,
+    ...stats,
+  }));
+}
+
+/** Null fields when there are fewer than 2 months of history, since best/worst would just be the same trivial month. */
+export function findBestAndWorstMonth(months: FcDataMonthStats[]): FcDataMonthHighlight {
+  if (months.length < 2) {
+    return { best: null, worst: null };
+  }
+
+  let best = months[0]!;
+  let worst = months[0]!;
+  for (const month of months) {
+    if (month.totalUnitsWon > best.totalUnitsWon) {
+      best = month;
+    }
+    if (month.totalUnitsWon < worst.totalUnitsWon) {
+      worst = month;
+    }
+  }
+
+  return { best, worst };
 }
 
 export function computeCumulativeSeries(rows: FcDataRow[]): FcDataCumulativePoint[] {
@@ -439,6 +499,41 @@ export function computeRoiSeries(rows: FcDataRow[]): FcDataRoiPoint[] {
   });
 }
 
+export const ROLLING_ROI_WINDOW = 30;
+
+/**
+ * ROI over just the trailing `windowSize` rounds ending at each point,
+ * rather than the all-time cumulative ROI - shows whether recent form is
+ * trending up or down.
+ */
+export function computeRollingRoiSeries(
+  rows: FcDataRow[],
+  windowSize: number = ROLLING_ROI_WINDOW,
+): FcDataRoiPoint[] {
+  const unitsWonWindow: number[] = [];
+  const betLinesWindow: number[] = [];
+  let windowUnitsWon = 0;
+  let windowBetLines = 0;
+
+  return rows.map(row => {
+    const lines = activeBetLineCount(row.url);
+    unitsWonWindow.push(row.unitsWon);
+    betLinesWindow.push(lines);
+    windowUnitsWon += row.unitsWon;
+    windowBetLines += lines;
+
+    if (unitsWonWindow.length > windowSize) {
+      windowUnitsWon -= unitsWonWindow.shift()!;
+      windowBetLines -= betLinesWindow.shift()!;
+    }
+
+    return {
+      round: row.round,
+      roi: windowBetLines > 0 ? windowUnitsWon / windowBetLines : 0,
+    };
+  });
+}
+
 export function findMissedRoundGaps(rows: FcDataRow[]): FcDataMissedRoundGap[] {
   const gaps: FcDataMissedRoundGap[] = [];
 
@@ -452,4 +547,40 @@ export function findMissedRoundGaps(rows: FcDataRow[]): FcDataMissedRoundGap[] {
   }
 
   return gaps;
+}
+
+/** A short, Discord-friendly plain-text stats blurb, ready to paste back into the server the CSV came from. */
+export function buildShareSummary(totals: FcDataTotals): string {
+  if (totals.roundsRecorded === 0) {
+    return 'No FC Data loaded yet.';
+  }
+
+  const lines: string[] = [
+    `NeoFoodClub stats: ${totals.roundsRecorded.toLocaleString()} rounds tracked`,
+    `Total won: ${Math.round(totals.totalUnitsWon).toLocaleString()} units | Win rate: ${(totals.winRate * 100).toFixed(1)}% | Avg/round: ${totals.averageUnitsPerRound.toFixed(1)}`,
+  ];
+
+  if (totals.bestRound) {
+    lines.push(
+      `Best round: #${totals.bestRound.round} (${Math.round(totals.bestRound.unitsWon).toLocaleString()} units)`,
+    );
+  }
+
+  if (totals.currentStreak) {
+    const { type, count, totalUnitsWon } = totals.currentStreak;
+    const noun = type === 'win' ? 'win' : 'bust';
+    const unitsSuffix =
+      type === 'win' ? ` (${Math.round(totalUnitsWon).toLocaleString()} units)` : '';
+    lines.push(`Current streak: ${count} ${noun}${count === 1 ? '' : 's'}${unitsSuffix}`);
+  }
+
+  if (totals.longestWinStreak) {
+    lines.push(
+      `Longest win streak: ${totals.longestWinStreak.count} (${Math.round(totals.longestWinStreak.totalUnitsWon).toLocaleString()} units)`,
+    );
+  }
+
+  lines.push('via neofood.club FC Data Visualizer');
+
+  return lines.join('\n');
 }

--- a/src/app/analysis/fcDataStats.ts
+++ b/src/app/analysis/fcDataStats.ts
@@ -1,0 +1,183 @@
+import { format } from 'date-fns';
+
+import type { FcDataRow } from '../data/fcDataCsv';
+
+export interface FcDataTotals {
+  roundsRecorded: number;
+  totalUnitsWon: number;
+  averageUnitsPerRound: number;
+  /** Fraction of rounds with unitsWon > 0, 0..1. */
+  winRate: number;
+  /** Highest unitsWon; first occurrence wins ties. Null when there are no rows. */
+  bestRound: FcDataRow | null;
+  longestWinStreak: number;
+  longestLossStreak: number;
+  firstRound: FcDataRow | null;
+  lastRound: FcDataRow | null;
+}
+
+export interface FcDataMonthStats {
+  /** e.g. "2024-04" - sortable, stable key. */
+  monthKey: string;
+  /** e.g. "Apr 2024". */
+  label: string;
+  roundsPlayed: number;
+  totalUnitsWon: number;
+  averageUnitsPerRound: number;
+  winRate: number;
+  bestRound: FcDataRow | null;
+}
+
+export interface FcDataCumulativePoint {
+  round: number;
+  cumulative: number;
+}
+
+export interface FcDataMissedRoundGap {
+  afterRound: number;
+  beforeRound: number;
+  missingCount: number;
+}
+
+export interface FcDataDayOfWeekStats {
+  /** 0=Sun..6=Sat, matching Date#getDay(). */
+  dayOfWeek: number;
+  label: string;
+  roundsPlayed: number;
+  totalUnitsWon: number;
+  averageUnitsPerRound: number;
+}
+
+const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+function longestRun(rows: FcDataRow[], predicate: (row: FcDataRow) => boolean): number {
+  let longest = 0;
+  let current = 0;
+  for (const row of rows) {
+    if (predicate(row)) {
+      current += 1;
+      longest = Math.max(longest, current);
+    } else {
+      current = 0;
+    }
+  }
+  return longest;
+}
+
+export function computeTotals(rows: FcDataRow[]): FcDataTotals {
+  if (rows.length === 0) {
+    return {
+      roundsRecorded: 0,
+      totalUnitsWon: 0,
+      averageUnitsPerRound: 0,
+      winRate: 0,
+      bestRound: null,
+      longestWinStreak: 0,
+      longestLossStreak: 0,
+      firstRound: null,
+      lastRound: null,
+    };
+  }
+
+  const totalUnitsWon = rows.reduce((sum, row) => sum + row.unitsWon, 0);
+  const winningRounds = rows.filter(row => row.unitsWon > 0).length;
+
+  let bestRound = rows[0]!;
+  for (const row of rows) {
+    if (row.unitsWon > bestRound.unitsWon) {
+      bestRound = row;
+    }
+  }
+
+  return {
+    roundsRecorded: rows.length,
+    totalUnitsWon,
+    averageUnitsPerRound: totalUnitsWon / rows.length,
+    winRate: winningRounds / rows.length,
+    bestRound,
+    longestWinStreak: longestRun(rows, row => row.unitsWon > 0),
+    longestLossStreak: longestRun(rows, row => row.unitsWon === 0),
+    firstRound: rows[0]!,
+    lastRound: rows[rows.length - 1]!,
+  };
+}
+
+export function computeMonthlyStats(rows: FcDataRow[]): FcDataMonthStats[] {
+  const byMonth = new Map<string, FcDataRow[]>();
+
+  for (const row of rows) {
+    const monthKey = format(row.date, 'yyyy-MM');
+    const bucket = byMonth.get(monthKey);
+    if (bucket) {
+      bucket.push(row);
+    } else {
+      byMonth.set(monthKey, [row]);
+    }
+  }
+
+  return Array.from(byMonth.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([monthKey, monthRows]) => {
+      const totalUnitsWon = monthRows.reduce((sum, row) => sum + row.unitsWon, 0);
+      const winningRounds = monthRows.filter(row => row.unitsWon > 0).length;
+
+      let bestRound = monthRows[0]!;
+      for (const row of monthRows) {
+        if (row.unitsWon > bestRound.unitsWon) {
+          bestRound = row;
+        }
+      }
+
+      return {
+        monthKey,
+        label: format(monthRows[0]!.date, 'MMM yyyy'),
+        roundsPlayed: monthRows.length,
+        totalUnitsWon,
+        averageUnitsPerRound: totalUnitsWon / monthRows.length,
+        winRate: winningRounds / monthRows.length,
+        bestRound,
+      };
+    });
+}
+
+export function computeCumulativeSeries(rows: FcDataRow[]): FcDataCumulativePoint[] {
+  let cumulative = 0;
+  return rows.map(row => {
+    cumulative += row.unitsWon;
+    return { round: row.round, cumulative };
+  });
+}
+
+export function findMissedRoundGaps(rows: FcDataRow[]): FcDataMissedRoundGap[] {
+  const gaps: FcDataMissedRoundGap[] = [];
+
+  for (let i = 1; i < rows.length; i++) {
+    const afterRound = rows[i - 1]!.round;
+    const beforeRound = rows[i]!.round;
+    const missingCount = beforeRound - afterRound - 1;
+    if (missingCount > 0) {
+      gaps.push({ afterRound, beforeRound, missingCount });
+    }
+  }
+
+  return gaps;
+}
+
+export function computeDayOfWeekStats(rows: FcDataRow[]): FcDataDayOfWeekStats[] {
+  const buckets: FcDataRow[][] = Array.from({ length: 7 }, () => []);
+
+  for (const row of rows) {
+    buckets[row.date.getDay()]!.push(row);
+  }
+
+  return buckets.map((bucketRows, dayOfWeek) => {
+    const totalUnitsWon = bucketRows.reduce((sum, row) => sum + row.unitsWon, 0);
+    return {
+      dayOfWeek,
+      label: DAY_LABELS[dayOfWeek]!,
+      roundsPlayed: bucketRows.length,
+      totalUnitsWon,
+      averageUnitsPerRound: bucketRows.length > 0 ? totalUnitsWon / bucketRows.length : 0,
+    };
+  });
+}

--- a/src/app/analysis/fcDataStats.ts
+++ b/src/app/analysis/fcDataStats.ts
@@ -76,17 +76,120 @@ export type FcDataReturnDistribution = Record<FcDataReturnBucket, number> & { to
 
 /** Number of bet lines with at least one non-zero pirate pick, decoded from the round's URL. */
 export function activeBetLineCount(url: string): number {
+  return decodeActiveLines(url).length;
+}
+
+/** One entry per active bet line: 5 positions (1-4, or 0 for "no pick"), one per arena. */
+export function decodeActiveLines(url: string): number[][] {
   const hashIndex = url.indexOf('#');
   const fragment = hashIndex === -1 ? url : url.slice(hashIndex + 1);
   const { bets } = parseBetUrl(fragment);
 
-  let count = 0;
-  for (const pirates of bets.values()) {
-    if (pirates.some(index => index > 0)) {
-      count += 1;
+  const lines: number[][] = [];
+  for (const positions of bets.values()) {
+    if (positions.some(position => position > 0)) {
+      lines.push(positions);
     }
   }
-  return count;
+  return lines;
+}
+
+export type FcDataBetShapeBucket = 'gambit' | 'bustproof' | 'crazy' | 'tenbet' | 'other';
+
+export interface FcDataBetShapeCounts {
+  /** Every active line's picks are a subset of one fixed 5-pirate combo (see `classifyBetShape`). */
+  gambitShaped: number;
+  /** Some arena has all 4 of its pirates covered across the lines. */
+  bustproofShaped: number;
+  /** Every line picks a pirate in all 5 arenas (no arena skipped). */
+  crazyShaped: number;
+  /** One (arena, pirate) pair is held fixed across every active line. */
+  tenbetShaped: number;
+  other: number;
+  total: number;
+}
+
+/**
+ * Classifies a round's decoded bet lines by structure, checked in order:
+ * - `gambit`: every arena has at most one distinct nonzero position across
+ *   all lines (every line is a subset of one fixed 5-pirate combo).
+ * - `bustproof`: some arena has all 4 of its pirates covered across the
+ *   lines (matches `make_bustproof_bets` in the neofoodclub engine, which
+ *   fully covers one or more "positive" arenas so that arena can't bust).
+ * - `crazy`: every line picks a pirate in all 5 arenas, no arena skipped
+ *   (matches `make_crazy_bets`'s "randomly-selected, full-arena bets").
+ * - `tenbet`: some arena holds one fixed nonzero position across every
+ *   line (one "anchor" pirate present in every line), while other arenas vary.
+ * - `other`: none of the above, or too few lines to tell (single-line bets).
+ */
+function classifyBetShape(lines: number[][]): FcDataBetShapeBucket {
+  if (lines.length <= 1) {
+    return 'other';
+  }
+
+  const positionsByArena = Array.from(
+    { length: 5 },
+    (_unused, arena) =>
+      new Set(lines.map(line => line[arena]).filter((p): p is number => !!p && p > 0)),
+  );
+
+  if (positionsByArena.every(positions => positions.size <= 1)) {
+    return 'gambit';
+  }
+
+  if (positionsByArena.some(positions => positions.size === 4)) {
+    return 'bustproof';
+  }
+
+  if (lines.every(line => line.every(position => position > 0))) {
+    return 'crazy';
+  }
+
+  for (let arena = 0; arena < 5; arena++) {
+    const first = lines[0]![arena]!;
+    if (first > 0 && lines.every(line => line[arena] === first)) {
+      return 'tenbet';
+    }
+  }
+
+  return 'other';
+}
+
+const BET_SHAPE_KEYS: Record<FcDataBetShapeBucket, keyof FcDataBetShapeCounts> = {
+  gambit: 'gambitShaped',
+  bustproof: 'bustproofShaped',
+  crazy: 'crazyShaped',
+  tenbet: 'tenbetShaped',
+  other: 'other',
+};
+
+/**
+ * Buckets each row's bet by structural shape, decoded purely from its bet
+ * hash - no round-history data needed (unlike pirate/arena identity, this
+ * doesn't depend on knowing which real pirate each position maps to).
+ */
+export function computeBetShapeCounts(rows: FcDataRow[]): FcDataBetShapeCounts {
+  const counts: FcDataBetShapeCounts = {
+    gambitShaped: 0,
+    bustproofShaped: 0,
+    crazyShaped: 0,
+    tenbetShaped: 0,
+    other: 0,
+    total: 0,
+  };
+
+  for (const row of rows) {
+    const lines = decodeActiveLines(row.url);
+    if (lines.length === 0) {
+      continue;
+    }
+
+    const shape = classifyBetShape(lines);
+    counts[BET_SHAPE_KEYS[shape]] += 1;
+    counts.total += 1;
+  }
+
+  return counts;
 }
 
 /**

--- a/src/app/analysis/fcDataStats.ts
+++ b/src/app/analysis/fcDataStats.ts
@@ -57,6 +57,12 @@ export interface FcDataCumulativePoint {
   cumulative: number;
 }
 
+export interface FcDataRoiPoint {
+  round: number;
+  /** Cumulative units won / cumulative active bet lines through this round. */
+  roi: number;
+}
+
 export interface FcDataMissedRoundGap {
   afterRound: number;
   beforeRound: number;
@@ -225,6 +231,20 @@ export function computeCumulativeSeries(rows: FcDataRow[]): FcDataCumulativePoin
   return rows.map(row => {
     cumulative += row.unitsWon;
     return { round: row.round, cumulative };
+  });
+}
+
+export function computeRoiSeries(rows: FcDataRow[]): FcDataRoiPoint[] {
+  let cumulativeUnitsWon = 0;
+  let cumulativeBetLines = 0;
+
+  return rows.map(row => {
+    cumulativeUnitsWon += row.unitsWon;
+    cumulativeBetLines += activeBetLineCount(row.url);
+    return {
+      round: row.round,
+      roi: cumulativeBetLines > 0 ? cumulativeUnitsWon / cumulativeBetLines : 0,
+    };
   });
 }
 

--- a/src/app/analysis/fcDataStats.ts
+++ b/src/app/analysis/fcDataStats.ts
@@ -19,6 +19,8 @@ export interface FcDataLossStreak {
 export interface FcDataCurrentStreak {
   type: 'win' | 'bust';
   count: number;
+  /** Always 0 for a bust streak. */
+  totalUnitsWon: number;
   startDate: Date;
   endDate: Date;
 }
@@ -306,6 +308,7 @@ function currentStreak(rows: FcDataRow[]): FcDataCurrentStreak | null {
   const type: FcDataCurrentStreak['type'] = last.unitsWon > 0 ? 'win' : 'bust';
 
   let count = 0;
+  let totalUnitsWon = 0;
   let startIndex = rows.length - 1;
   for (let i = rows.length - 1; i >= 0; i--) {
     const isMatch = type === 'win' ? rows[i]!.unitsWon > 0 : rows[i]!.unitsWon === 0;
@@ -313,12 +316,14 @@ function currentStreak(rows: FcDataRow[]): FcDataCurrentStreak | null {
       break;
     }
     count += 1;
+    totalUnitsWon += rows[i]!.unitsWon;
     startIndex = i;
   }
 
   return {
     type,
     count,
+    totalUnitsWon,
     startDate: rows[startIndex]!.date,
     endDate: last.date,
   };

--- a/src/app/analysis/fcDataStats.ts
+++ b/src/app/analysis/fcDataStats.ts
@@ -16,6 +16,13 @@ export interface FcDataLossStreak {
   endDate: Date;
 }
 
+export interface FcDataCurrentStreak {
+  type: 'win' | 'bust';
+  count: number;
+  startDate: Date;
+  endDate: Date;
+}
+
 export interface FcDataTotals {
   roundsRecorded: number;
   totalUnitsWon: number;
@@ -28,6 +35,8 @@ export interface FcDataTotals {
   longestWinStreak: FcDataWinStreak | null;
   /** Null when every round won something. */
   longestLossStreak: FcDataLossStreak | null;
+  /** The still-ongoing streak ending at the most recent recorded round. Null when there are no rows. */
+  currentStreak: FcDataCurrentStreak | null;
   firstRound: FcDataRow | null;
   lastRound: FcDataRow | null;
 }
@@ -287,6 +296,34 @@ function longestLossStreak(rows: FcDataRow[]): FcDataLossStreak | null {
   return best;
 }
 
+/** The still-ongoing streak ending at the most recent row (assumes rows are round-ascending). */
+function currentStreak(rows: FcDataRow[]): FcDataCurrentStreak | null {
+  if (rows.length === 0) {
+    return null;
+  }
+
+  const last = rows[rows.length - 1]!;
+  const type: FcDataCurrentStreak['type'] = last.unitsWon > 0 ? 'win' : 'bust';
+
+  let count = 0;
+  let startIndex = rows.length - 1;
+  for (let i = rows.length - 1; i >= 0; i--) {
+    const isMatch = type === 'win' ? rows[i]!.unitsWon > 0 : rows[i]!.unitsWon === 0;
+    if (!isMatch) {
+      break;
+    }
+    count += 1;
+    startIndex = i;
+  }
+
+  return {
+    type,
+    count,
+    startDate: rows[startIndex]!.date,
+    endDate: last.date,
+  };
+}
+
 export function computeTotals(rows: FcDataRow[]): FcDataTotals {
   if (rows.length === 0) {
     return {
@@ -297,6 +334,7 @@ export function computeTotals(rows: FcDataRow[]): FcDataTotals {
       bestRound: null,
       longestWinStreak: null,
       longestLossStreak: null,
+      currentStreak: null,
       firstRound: null,
       lastRound: null,
     };
@@ -320,6 +358,7 @@ export function computeTotals(rows: FcDataRow[]): FcDataTotals {
     bestRound,
     longestWinStreak: longestWinStreak(rows),
     longestLossStreak: longestLossStreak(rows),
+    currentStreak: currentStreak(rows),
     firstRound: rows[0]!,
     lastRound: rows[rows.length - 1]!,
   };

--- a/src/app/analysis/fcDataStats.ts
+++ b/src/app/analysis/fcDataStats.ts
@@ -69,6 +69,11 @@ export interface FcDataMissedRoundGap {
   missingCount: number;
 }
 
+export type FcDataReturnBucket = 'bust' | 'partial' | 'profit' | 'double';
+
+/** Round counts per return bucket (see `classifyRoundReturn`). `total` is the sum of all four. */
+export type FcDataReturnDistribution = Record<FcDataReturnBucket, number> & { total: number };
+
 /** Number of bet lines with at least one non-zero pirate pick, decoded from the round's URL. */
 export function activeBetLineCount(url: string): number {
   const hashIndex = url.indexOf('#');
@@ -82,6 +87,45 @@ export function activeBetLineCount(url: string): number {
     }
   }
   return count;
+}
+
+/**
+ * Buckets a single round's return relative to its active bet lines: `bust`
+ * (won nothing), `partial` (won something but under 1x per line), `profit`
+ * (1x-2x per line), `double` (2x or more per line).
+ */
+export function classifyRoundReturn(row: FcDataRow): FcDataReturnBucket {
+  if (row.unitsWon === 0) {
+    return 'bust';
+  }
+
+  const lines = activeBetLineCount(row.url);
+  const roi = lines > 0 ? row.unitsWon / lines : 0;
+
+  if (roi < 1) {
+    return 'partial';
+  }
+  if (roi < 2) {
+    return 'profit';
+  }
+  return 'double';
+}
+
+export function computeReturnDistribution(rows: FcDataRow[]): FcDataReturnDistribution {
+  const distribution: FcDataReturnDistribution = {
+    bust: 0,
+    partial: 0,
+    profit: 0,
+    double: 0,
+    total: 0,
+  };
+
+  for (const row of rows) {
+    distribution[classifyRoundReturn(row)] += 1;
+    distribution.total += 1;
+  }
+
+  return distribution;
 }
 
 function longestWinStreak(rows: FcDataRow[]): FcDataWinStreak | null {

--- a/src/app/analysis/fcDataStats.ts
+++ b/src/app/analysis/fcDataStats.ts
@@ -1,6 +1,20 @@
 import { format } from 'date-fns';
 
 import type { FcDataRow } from '../data/fcDataCsv';
+import { parseBetUrl } from '../util';
+
+export interface FcDataWinStreak {
+  count: number;
+  totalUnitsWon: number;
+  startDate: Date;
+  endDate: Date;
+}
+
+export interface FcDataLossStreak {
+  count: number;
+  startDate: Date;
+  endDate: Date;
+}
 
 export interface FcDataTotals {
   roundsRecorded: number;
@@ -10,8 +24,10 @@ export interface FcDataTotals {
   winRate: number;
   /** Highest unitsWon; first occurrence wins ties. Null when there are no rows. */
   bestRound: FcDataRow | null;
-  longestWinStreak: number;
-  longestLossStreak: number;
+  /** Null when no round ever won anything. */
+  longestWinStreak: FcDataWinStreak | null;
+  /** Null when every round won something. */
+  longestLossStreak: FcDataLossStreak | null;
   firstRound: FcDataRow | null;
   lastRound: FcDataRow | null;
 }
@@ -26,6 +42,14 @@ export interface FcDataMonthStats {
   averageUnitsPerRound: number;
   winRate: number;
   bestRound: FcDataRow | null;
+  /**
+   * totalUnitsWon / total active bet lines that month (not real NP wagered -
+   * there's no bet-amount data in the CSV, just a per-line proxy). 1.0 means
+   * each bet line broke even on average.
+   */
+  roi: number;
+  /** Same as `roi`, but accumulated across every month up to and including this one. */
+  cumulativeRoi: number;
 }
 
 export interface FcDataCumulativePoint {
@@ -39,29 +63,75 @@ export interface FcDataMissedRoundGap {
   missingCount: number;
 }
 
-export interface FcDataDayOfWeekStats {
-  /** 0=Sun..6=Sat, matching Date#getDay(). */
-  dayOfWeek: number;
-  label: string;
-  roundsPlayed: number;
-  totalUnitsWon: number;
-  averageUnitsPerRound: number;
-}
+/** Number of bet lines with at least one non-zero pirate pick, decoded from the round's URL. */
+export function activeBetLineCount(url: string): number {
+  const hashIndex = url.indexOf('#');
+  const fragment = hashIndex === -1 ? url : url.slice(hashIndex + 1);
+  const { bets } = parseBetUrl(fragment);
 
-const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-
-function longestRun(rows: FcDataRow[], predicate: (row: FcDataRow) => boolean): number {
-  let longest = 0;
-  let current = 0;
-  for (const row of rows) {
-    if (predicate(row)) {
-      current += 1;
-      longest = Math.max(longest, current);
-    } else {
-      current = 0;
+  let count = 0;
+  for (const pirates of bets.values()) {
+    if (pirates.some(index => index > 0)) {
+      count += 1;
     }
   }
-  return longest;
+  return count;
+}
+
+function longestWinStreak(rows: FcDataRow[]): FcDataWinStreak | null {
+  let best: FcDataWinStreak | null = null;
+  let currentCount = 0;
+  let currentUnitsWon = 0;
+  let currentStartIndex = -1;
+
+  rows.forEach((row, index) => {
+    if (row.unitsWon > 0) {
+      if (currentCount === 0) {
+        currentStartIndex = index;
+      }
+      currentCount += 1;
+      currentUnitsWon += row.unitsWon;
+      if (!best || currentCount > best.count) {
+        best = {
+          count: currentCount,
+          totalUnitsWon: currentUnitsWon,
+          startDate: rows[currentStartIndex]!.date,
+          endDate: row.date,
+        };
+      }
+    } else {
+      currentCount = 0;
+      currentUnitsWon = 0;
+    }
+  });
+
+  return best;
+}
+
+function longestLossStreak(rows: FcDataRow[]): FcDataLossStreak | null {
+  let best: FcDataLossStreak | null = null;
+  let currentCount = 0;
+  let currentStartIndex = -1;
+
+  rows.forEach((row, index) => {
+    if (row.unitsWon === 0) {
+      if (currentCount === 0) {
+        currentStartIndex = index;
+      }
+      currentCount += 1;
+      if (!best || currentCount > best.count) {
+        best = {
+          count: currentCount,
+          startDate: rows[currentStartIndex]!.date,
+          endDate: row.date,
+        };
+      }
+    } else {
+      currentCount = 0;
+    }
+  });
+
+  return best;
 }
 
 export function computeTotals(rows: FcDataRow[]): FcDataTotals {
@@ -72,8 +142,8 @@ export function computeTotals(rows: FcDataRow[]): FcDataTotals {
       averageUnitsPerRound: 0,
       winRate: 0,
       bestRound: null,
-      longestWinStreak: 0,
-      longestLossStreak: 0,
+      longestWinStreak: null,
+      longestLossStreak: null,
       firstRound: null,
       lastRound: null,
     };
@@ -95,8 +165,8 @@ export function computeTotals(rows: FcDataRow[]): FcDataTotals {
     averageUnitsPerRound: totalUnitsWon / rows.length,
     winRate: winningRounds / rows.length,
     bestRound,
-    longestWinStreak: longestRun(rows, row => row.unitsWon > 0),
-    longestLossStreak: longestRun(rows, row => row.unitsWon === 0),
+    longestWinStreak: longestWinStreak(rows),
+    longestLossStreak: longestLossStreak(rows),
     firstRound: rows[0]!,
     lastRound: rows[rows.length - 1]!,
   };
@@ -115,6 +185,9 @@ export function computeMonthlyStats(rows: FcDataRow[]): FcDataMonthStats[] {
     }
   }
 
+  let cumulativeUnitsWon = 0;
+  let cumulativeBetLines = 0;
+
   return Array.from(byMonth.entries())
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([monthKey, monthRows]) => {
@@ -128,6 +201,11 @@ export function computeMonthlyStats(rows: FcDataRow[]): FcDataMonthStats[] {
         }
       }
 
+      const totalBetLines = monthRows.reduce((sum, row) => sum + activeBetLineCount(row.url), 0);
+
+      cumulativeUnitsWon += totalUnitsWon;
+      cumulativeBetLines += totalBetLines;
+
       return {
         monthKey,
         label: format(monthRows[0]!.date, 'MMM yyyy'),
@@ -136,6 +214,8 @@ export function computeMonthlyStats(rows: FcDataRow[]): FcDataMonthStats[] {
         averageUnitsPerRound: totalUnitsWon / monthRows.length,
         winRate: winningRounds / monthRows.length,
         bestRound,
+        roi: totalBetLines > 0 ? totalUnitsWon / totalBetLines : 0,
+        cumulativeRoi: cumulativeBetLines > 0 ? cumulativeUnitsWon / cumulativeBetLines : 0,
       };
     });
 }
@@ -161,23 +241,4 @@ export function findMissedRoundGaps(rows: FcDataRow[]): FcDataMissedRoundGap[] {
   }
 
   return gaps;
-}
-
-export function computeDayOfWeekStats(rows: FcDataRow[]): FcDataDayOfWeekStats[] {
-  const buckets: FcDataRow[][] = Array.from({ length: 7 }, () => []);
-
-  for (const row of rows) {
-    buckets[row.date.getDay()]!.push(row);
-  }
-
-  return buckets.map((bucketRows, dayOfWeek) => {
-    const totalUnitsWon = bucketRows.reduce((sum, row) => sum + row.unitsWon, 0);
-    return {
-      dayOfWeek,
-      label: DAY_LABELS[dayOfWeek]!,
-      roundsPlayed: bucketRows.length,
-      totalUnitsWon,
-      averageUnitsPerRound: bucketRows.length > 0 ? totalUnitsWon / bucketRows.length : 0,
-    };
-  });
 }

--- a/src/app/components/charts/FcDataBetShapesChart.tsx
+++ b/src/app/components/charts/FcDataBetShapesChart.tsx
@@ -1,0 +1,75 @@
+import { Box, Card } from '@chakra-ui/react';
+import { Chart as ChartJS, ArcElement, Tooltip, Legend, TooltipItem } from 'chart.js';
+import React, { useMemo } from 'react';
+import { Pie } from 'react-chartjs-2';
+
+import type { FcDataBetShapeCounts } from '../../analysis/fcDataStats';
+
+ChartJS.register(ArcElement, Tooltip, Legend);
+
+const GAMBIT_COLOR = '#3182ce';
+const BUSTPROOF_COLOR = '#38a169';
+const CRAZY_COLOR = '#dd6b20';
+const TENBET_COLOR = '#805ad5';
+const OTHER_COLOR = '#a0aec0';
+
+interface FcDataBetShapesChartProps {
+  shapes: FcDataBetShapeCounts;
+}
+
+export function FcDataBetShapesChart({ shapes }: FcDataBetShapesChartProps): React.JSX.Element {
+  const data = useMemo(
+    () => ({
+      labels: ['Gambit', 'Bustproof', 'Crazy', 'Tenbet', 'Other'],
+      datasets: [
+        {
+          data: [
+            shapes.gambitShaped,
+            shapes.bustproofShaped,
+            shapes.crazyShaped,
+            shapes.tenbetShaped,
+            shapes.other,
+          ],
+          backgroundColor: [GAMBIT_COLOR, BUSTPROOF_COLOR, CRAZY_COLOR, TENBET_COLOR, OTHER_COLOR],
+          borderColor: 'transparent',
+          borderWidth: 0,
+        },
+      ],
+    }),
+    [shapes],
+  );
+
+  const options = useMemo(
+    () => ({
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: {
+          position: 'bottom' as const,
+        },
+        tooltip: {
+          itemSort: (a: TooltipItem<'pie'>, b: TooltipItem<'pie'>): number => b.parsed - a.parsed,
+          callbacks: {
+            label: (context: TooltipItem<'pie'>): string => {
+              const value = context.parsed;
+              const pct = shapes.total > 0 ? ((value / shapes.total) * 100).toFixed(1) : '0.0';
+              return ` ${context.label}: ${value} (${pct}%)`;
+            },
+          },
+        },
+      },
+    }),
+    [shapes.total],
+  );
+
+  return (
+    <Card.Root boxShadow="md">
+      <Card.Body p={2}>
+        <Box w="full" h={{ base: '240px', md: '280px' }}>
+          {/* @ts-ignore */}
+          <Pie data={data} options={options} />
+        </Box>
+      </Card.Body>
+    </Card.Root>
+  );
+}

--- a/src/app/components/charts/FcDataCumulativeChart.tsx
+++ b/src/app/components/charts/FcDataCumulativeChart.tsx
@@ -1,0 +1,120 @@
+import { Box, Card } from '@chakra-ui/react';
+import {
+  Chart as ChartJS,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+  TooltipItem,
+} from 'chart.js';
+import React, { useMemo } from 'react';
+import { Line } from 'react-chartjs-2';
+
+import type { FcDataCumulativePoint } from '../../analysis/fcDataStats';
+
+import { useColorMode } from '@/components/ui/color-mode';
+
+ChartJS.register(LinearScale, PointElement, LineElement, Tooltip, Legend);
+
+const LINE_COLOR = '#38a169';
+
+interface FcDataCumulativeChartProps {
+  series: FcDataCumulativePoint[];
+}
+
+export function FcDataCumulativeChart({ series }: FcDataCumulativeChartProps): React.JSX.Element {
+  const { colorMode } = useColorMode();
+  const isDarkLikeMode = colorMode !== 'light';
+
+  const data = useMemo(
+    () => ({
+      datasets: [
+        {
+          label: 'Cumulative units won',
+          data: series.map(point => ({ x: point.round, y: point.cumulative })),
+          borderColor: LINE_COLOR,
+          backgroundColor: LINE_COLOR,
+          pointRadius: 0,
+          borderWidth: 2,
+        },
+      ],
+    }),
+    [series],
+  );
+
+  const gridColor = isDarkLikeMode ? '#6272a4' : undefined;
+  const textColor = isDarkLikeMode ? '#ffffff' : undefined;
+
+  const options = useMemo(
+    () => ({
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: {
+          display: false,
+        },
+        tooltip: {
+          callbacks: {
+            title: (items: TooltipItem<'line'>[]): string => {
+              const round = items[0]?.parsed.x;
+              return round !== undefined ? `Round ${round}` : '';
+            },
+            label: (context: TooltipItem<'line'>): string =>
+              `Cumulative: ${(context.parsed.y ?? 0).toLocaleString()}`,
+          },
+        },
+      },
+      interaction: {
+        mode: 'index' as const,
+        intersect: false,
+      },
+      animation: {
+        duration: 0,
+      },
+      scales: {
+        x: {
+          type: 'linear' as const,
+          title: {
+            display: true,
+            text: 'Round',
+            color: textColor,
+          },
+          ticks: {
+            color: textColor,
+          },
+          grid: {
+            color: gridColor,
+            borderColor: gridColor,
+          },
+        },
+        y: {
+          title: {
+            display: true,
+            text: 'Cumulative Units Won',
+            color: textColor,
+          },
+          ticks: {
+            color: textColor,
+          },
+          grid: {
+            color: gridColor,
+            borderColor: gridColor,
+          },
+        },
+      },
+    }),
+    [gridColor, textColor],
+  );
+
+  return (
+    <Card.Root boxShadow="md">
+      <Card.Body p={2}>
+        <Box w="full" h={{ base: '260px', md: '360px' }}>
+          {/* @ts-ignore */}
+          <Line data={data} options={options} />
+        </Box>
+      </Card.Body>
+    </Card.Root>
+  );
+}

--- a/src/app/components/charts/FcDataMonthlyBarChart.tsx
+++ b/src/app/components/charts/FcDataMonthlyBarChart.tsx
@@ -1,0 +1,78 @@
+import { Box, Card } from '@chakra-ui/react';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Tooltip,
+  Legend,
+  TooltipItem,
+} from 'chart.js';
+import React, { useMemo } from 'react';
+import { Bar } from 'react-chartjs-2';
+
+import type { FcDataMonthStats } from '../../analysis/fcDataStats';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+
+const BAR_COLOR = '#3182ce';
+
+interface FcDataMonthlyBarChartProps {
+  months: FcDataMonthStats[];
+}
+
+export function FcDataMonthlyBarChart({ months }: FcDataMonthlyBarChartProps): React.JSX.Element {
+  const data = useMemo(
+    () => ({
+      labels: months.map(month => month.label),
+      datasets: [
+        {
+          label: 'Units won',
+          data: months.map(month => month.totalUnitsWon),
+          backgroundColor: BAR_COLOR,
+        },
+      ],
+    }),
+    [months],
+  );
+
+  const options = useMemo(
+    () => ({
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: {
+          display: false,
+        },
+        tooltip: {
+          callbacks: {
+            title: (items: TooltipItem<'bar'>[]): string => items[0]?.label ?? '',
+            label: (context: TooltipItem<'bar'>): string =>
+              `Units won: ${(context.parsed.y ?? 0).toLocaleString()}`,
+          },
+        },
+      },
+      scales: {
+        x: {
+          grid: { display: false },
+        },
+        y: {
+          beginAtZero: true,
+          ticks: { precision: 0 },
+        },
+      },
+    }),
+    [],
+  );
+
+  return (
+    <Card.Root boxShadow="md">
+      <Card.Body p={2}>
+        <Box w="full" h={{ base: '240px', md: '280px' }}>
+          {/* @ts-ignore */}
+          <Bar data={data} options={options} />
+        </Box>
+      </Card.Body>
+    </Card.Root>
+  );
+}

--- a/src/app/components/charts/FcDataRoiChart.tsx
+++ b/src/app/components/charts/FcDataRoiChart.tsx
@@ -19,14 +19,22 @@ import { useColorMode } from '@/components/ui/color-mode';
 ChartJS.register(LinearScale, PointElement, LineElement, Tooltip, Legend, annotationPlugin);
 
 const LINE_COLOR = '#dd6b20';
+const ROLLING_COLOR = '#805ad5';
 
 interface FcDataRoiChartProps {
   series: FcDataRoiPoint[];
+  rollingSeries?: FcDataRoiPoint[];
+  rollingLabel?: string;
 }
 
-export function FcDataRoiChart({ series }: FcDataRoiChartProps): React.JSX.Element {
+export function FcDataRoiChart({
+  series,
+  rollingSeries,
+  rollingLabel = 'Rolling ROI',
+}: FcDataRoiChartProps): React.JSX.Element {
   const { colorMode } = useColorMode();
   const isDarkLikeMode = colorMode !== 'light';
+  const hasRollingSeries = (rollingSeries?.length ?? 0) > 0;
 
   const data = useMemo(
     () => ({
@@ -39,9 +47,22 @@ export function FcDataRoiChart({ series }: FcDataRoiChartProps): React.JSX.Eleme
           pointRadius: 0,
           borderWidth: 2,
         },
+        ...(hasRollingSeries
+          ? [
+              {
+                label: rollingLabel,
+                data: rollingSeries!.map(point => ({ x: point.round, y: point.roi })),
+                borderColor: ROLLING_COLOR,
+                backgroundColor: ROLLING_COLOR,
+                pointRadius: 0,
+                borderWidth: 2,
+                borderDash: [4, 3],
+              },
+            ]
+          : []),
       ],
     }),
-    [series],
+    [series, rollingSeries, hasRollingSeries, rollingLabel],
   );
 
   const gridColor = isDarkLikeMode ? '#6272a4' : undefined;
@@ -53,7 +74,10 @@ export function FcDataRoiChart({ series }: FcDataRoiChartProps): React.JSX.Eleme
       maintainAspectRatio: false,
       plugins: {
         legend: {
-          display: false,
+          display: hasRollingSeries,
+          labels: {
+            color: textColor,
+          },
         },
         annotation: {
           annotations: {
@@ -126,7 +150,7 @@ export function FcDataRoiChart({ series }: FcDataRoiChartProps): React.JSX.Eleme
         },
       },
     }),
-    [gridColor, textColor, isDarkLikeMode],
+    [gridColor, textColor, isDarkLikeMode, hasRollingSeries],
   );
 
   return (

--- a/src/app/components/charts/FcDataRoiChart.tsx
+++ b/src/app/components/charts/FcDataRoiChart.tsx
@@ -1,0 +1,142 @@
+import { Box, Card } from '@chakra-ui/react';
+import {
+  Chart as ChartJS,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+  TooltipItem,
+} from 'chart.js';
+import annotationPlugin from 'chartjs-plugin-annotation';
+import React, { useMemo } from 'react';
+import { Line } from 'react-chartjs-2';
+
+import type { FcDataRoiPoint } from '../../analysis/fcDataStats';
+
+import { useColorMode } from '@/components/ui/color-mode';
+
+ChartJS.register(LinearScale, PointElement, LineElement, Tooltip, Legend, annotationPlugin);
+
+const LINE_COLOR = '#dd6b20';
+
+interface FcDataRoiChartProps {
+  series: FcDataRoiPoint[];
+}
+
+export function FcDataRoiChart({ series }: FcDataRoiChartProps): React.JSX.Element {
+  const { colorMode } = useColorMode();
+  const isDarkLikeMode = colorMode !== 'light';
+
+  const data = useMemo(
+    () => ({
+      datasets: [
+        {
+          label: 'Running ROI',
+          data: series.map(point => ({ x: point.round, y: point.roi })),
+          borderColor: LINE_COLOR,
+          backgroundColor: LINE_COLOR,
+          pointRadius: 0,
+          borderWidth: 2,
+        },
+      ],
+    }),
+    [series],
+  );
+
+  const gridColor = isDarkLikeMode ? '#6272a4' : undefined;
+  const textColor = isDarkLikeMode ? '#ffffff' : undefined;
+
+  const options = useMemo(
+    () => ({
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: {
+          display: false,
+        },
+        annotation: {
+          annotations: {
+            breakeven: {
+              type: 'line' as const,
+              yMin: 1,
+              yMax: 1,
+              borderColor: isDarkLikeMode ? '#a0aec0' : '#718096',
+              borderWidth: 1,
+              borderDash: [4, 4],
+              label: {
+                display: true,
+                content: 'Breakeven',
+                position: 'start' as const,
+                backgroundColor: 'transparent',
+                color: isDarkLikeMode ? '#a0aec0' : '#718096',
+                font: { size: 10 },
+              },
+            },
+          },
+        },
+        tooltip: {
+          callbacks: {
+            title: (items: TooltipItem<'line'>[]): string => {
+              const round = items[0]?.parsed.x;
+              return round !== undefined ? `Round ${round}` : '';
+            },
+            label: (context: TooltipItem<'line'>): string =>
+              `ROI: ${(context.parsed.y ?? 0).toFixed(2)}x`,
+          },
+        },
+      },
+      interaction: {
+        mode: 'index' as const,
+        intersect: false,
+      },
+      animation: {
+        duration: 0,
+      },
+      scales: {
+        x: {
+          type: 'linear' as const,
+          title: {
+            display: true,
+            text: 'Round',
+            color: textColor,
+          },
+          ticks: {
+            color: textColor,
+          },
+          grid: {
+            color: gridColor,
+            borderColor: gridColor,
+          },
+        },
+        y: {
+          title: {
+            display: true,
+            text: 'Running ROI',
+            color: textColor,
+          },
+          ticks: {
+            color: textColor,
+            callback: (value: number | string): string => `${Number(value).toFixed(1)}x`,
+          },
+          grid: {
+            color: gridColor,
+            borderColor: gridColor,
+          },
+        },
+      },
+    }),
+    [gridColor, textColor, isDarkLikeMode],
+  );
+
+  return (
+    <Card.Root boxShadow="md">
+      <Card.Body p={2}>
+        <Box w="full" h={{ base: '260px', md: '360px' }}>
+          {/* @ts-ignore */}
+          <Line data={data} options={options} />
+        </Box>
+      </Card.Body>
+    </Card.Root>
+  );
+}

--- a/src/app/components/dev/DevModeDrawer.tsx
+++ b/src/app/components/dev/DevModeDrawer.tsx
@@ -1,12 +1,20 @@
 import { Button, Drawer, Portal, Stack, CloseButton, Separator } from '@chakra-ui/react';
 import * as React from 'react';
-import { FaBalanceScale, FaCode, FaCrosshairs, FaStopwatch, FaTable } from 'react-icons/fa';
+import {
+  FaBalanceScale,
+  FaCode,
+  FaCrosshairs,
+  FaFileCsv,
+  FaStopwatch,
+  FaTable,
+} from 'react-icons/fa';
 import { FaMagnifyingGlassChart } from 'react-icons/fa6';
 
 import { useDisclosureState } from '../../hooks/useDisclosureState';
 import { getReactScanEnabled, setReactScanEnabled } from '../../util/reactScan';
 import { AllBetsModal } from '../modals/AllBetsModal';
 import { BacktestComparisonModal } from '../modals/BacktestComparisonModal';
+import { FcDataModal } from '../modals/FcDataModal';
 import { PirateMatchupModal } from '../modals/PirateMatchupModal';
 import { RoundEndDriftModal } from '../modals/RoundEndDriftModal';
 import { RoundJsonModal } from '../modals/RoundJsonModal';
@@ -23,6 +31,7 @@ export const DevModeDrawer: React.FC<DevModeDrawerProps> = ({ isOpen, onClose })
   const backtestModal = useDisclosureState(false);
   const driftModal = useDisclosureState(false);
   const matchupModal = useDisclosureState(false);
+  const fcDataModal = useDisclosureState(false);
   const [isReactScanEnabled, setIsReactScanEnabled] = React.useState(getReactScanEnabled);
 
   const handleReactScanToggle = React.useCallback((): void => {
@@ -81,6 +90,10 @@ export const DevModeDrawer: React.FC<DevModeDrawerProps> = ({ isOpen, onClose })
                     <FaCrosshairs />
                     Pirate Matchups (Head-to-Head)
                   </Button>
+                  <Button width="full" onClick={fcDataModal.onOpen}>
+                    <FaFileCsv />
+                    Import FC Data (NeoBot CSV)
+                  </Button>
                 </Stack>
               </Drawer.Body>
               <Drawer.Footer>
@@ -98,6 +111,7 @@ export const DevModeDrawer: React.FC<DevModeDrawerProps> = ({ isOpen, onClose })
       <BacktestComparisonModal isOpen={backtestModal.isOpen} onClose={backtestModal.onClose} />
       <RoundEndDriftModal isOpen={driftModal.isOpen} onClose={driftModal.onClose} />
       <PirateMatchupModal isOpen={matchupModal.isOpen} onClose={matchupModal.onClose} />
+      <FcDataModal isOpen={fcDataModal.isOpen} onClose={fcDataModal.onClose} />
     </>
   );
 };

--- a/src/app/components/dev/DevModeDrawer.tsx
+++ b/src/app/components/dev/DevModeDrawer.tsx
@@ -92,7 +92,7 @@ export const DevModeDrawer: React.FC<DevModeDrawerProps> = ({ isOpen, onClose })
                   </Button>
                   <Button width="full" onClick={fcDataModal.onOpen}>
                     <FaFileCsv />
-                    Import FC Data (NeoBot CSV)
+                    FC Data Visualizer (NeoBot CSV)
                   </Button>
                 </Stack>
               </Drawer.Body>

--- a/src/app/components/modals/FcDataModal.tsx
+++ b/src/app/components/modals/FcDataModal.tsx
@@ -15,19 +15,24 @@ import {
 } from '@chakra-ui/react';
 import { format } from 'date-fns';
 import * as React from 'react';
-import { FaFileCsv } from 'react-icons/fa';
+import { FaChartBar, FaFileCsv } from 'react-icons/fa';
 
+import { computeAdvancedStats, type FcDataAdvancedStats } from '../../analysis/fcDataAdvancedStats';
 import {
   computeCumulativeSeries,
   computeMonthlyStats,
+  computeReturnDistribution,
   computeRoiSeries,
   computeTotals,
   findMissedRoundGaps,
   type FcDataMissedRoundGap,
   type FcDataMonthStats,
+  type FcDataReturnBucket,
+  type FcDataReturnDistribution,
   type FcDataTotals,
 } from '../../analysis/fcDataStats';
 import { parseFcDataCsv, type FcDataParseResult, type FcDataRow } from '../../data/fcDataCsv';
+import { useBacktestPreviousRounds } from '../../hooks/useBacktestPreviousRounds';
 import { FcDataCumulativeChart } from '../charts/FcDataCumulativeChart';
 import { FcDataMonthlyBarChart } from '../charts/FcDataMonthlyBarChart';
 import { FcDataRoiChart } from '../charts/FcDataRoiChart';
@@ -51,7 +56,7 @@ function displayPercent(value: number): string {
 }
 
 function formatRoi(value: number): string {
-  return `${value.toFixed(2)}x`;
+  return `${value.toFixed(3)}x`;
 }
 
 function roiColor(value: number): string {
@@ -178,6 +183,56 @@ function FcDataTotalsSection({ totals }: { totals: FcDataTotals }): React.JSX.El
   );
 }
 
+const RETURN_BUCKET_ORDER: FcDataReturnBucket[] = ['bust', 'partial', 'profit', 'double'];
+
+const RETURN_BUCKET_LABELS: Record<FcDataReturnBucket, string> = {
+  bust: 'Bust',
+  partial: 'Partial',
+  profit: 'Profit',
+  double: 'Double+',
+};
+
+const RETURN_BUCKET_COLORS: Record<FcDataReturnBucket, string> = {
+  bust: '#e53e3e',
+  partial: '#dd6b20',
+  profit: '#38a169',
+  double: '#3182ce',
+};
+
+function FcDataReturnDistributionSection({
+  distribution,
+}: {
+  distribution: FcDataReturnDistribution;
+}): React.JSX.Element | null {
+  if (distribution.total === 0) {
+    return null;
+  }
+
+  return (
+    <SectionCard title="Return Distribution">
+      <Box h="20px" borderRadius="md" overflow="hidden" display="flex">
+        {RETURN_BUCKET_ORDER.filter(bucket => distribution[bucket] > 0).map(bucket => (
+          <Box
+            key={bucket}
+            bg={RETURN_BUCKET_COLORS[bucket]}
+            flexBasis={`${(distribution[bucket] / distribution.total) * 100}%`}
+          />
+        ))}
+      </Box>
+      <Text fontSize="sm" color="fg.muted">
+        {RETURN_BUCKET_ORDER.map(
+          bucket =>
+            `${RETURN_BUCKET_LABELS[bucket]} ${displayPercent(distribution[bucket] / distribution.total)}`,
+        ).join(' · ')}
+      </Text>
+      <Text fontSize="xs" color="fg.muted" fontStyle="italic">
+        Per round, relative to that round&apos;s active bet lines: Bust = won nothing, Partial =
+        under 1x, Profit = 1x-2x, Double+ = 2x or more.
+      </Text>
+    </SectionCard>
+  );
+}
+
 function FcDataMonthlyTable({ months }: { months: FcDataMonthStats[] }): React.JSX.Element {
   return (
     <SectionCard title="Per-Month Breakdown">
@@ -223,7 +278,7 @@ function FcDataMonthlyTable({ months }: { months: FcDataMonthStats[] }): React.J
       </Box>
       <Text fontSize="xs" color="fg.muted" fontStyle="italic">
         ROI is units won per active bet line (not real NP wagered - the CSV has no bet amounts),
-        where 1.00x means breaking even. Running ROI accumulates from the first recorded round
+        where 1.000x means breaking even. Running ROI accumulates from the first recorded round
         through the end of that month.
       </Text>
     </SectionCard>
@@ -299,6 +354,139 @@ function FcDataWarningsSection({
         ))}
       </Stack>
     </Stack>
+  );
+}
+
+const EXPOSURE_BAR_COLOR = '#3182ce';
+const MAX_EXPOSURE_ROWS = 10;
+
+function PirateExposureBar({
+  name,
+  rate,
+  maxRate,
+}: {
+  name: string;
+  rate: number;
+  maxRate: number;
+}): React.JSX.Element {
+  return (
+    <HStack gap={2}>
+      <Text fontSize="sm" w="120px" flexShrink={0} truncate>
+        {name}
+      </Text>
+      <Box flex={1} h="14px" bg="bg.muted" borderRadius="sm" overflow="hidden">
+        <Box h="full" bg={EXPOSURE_BAR_COLOR} w={`${(rate / maxRate) * 100}%`} />
+      </Box>
+      <Text fontSize="sm" w="46px" textAlign="right" flexShrink={0}>
+        {displayPercent(rate)}
+      </Text>
+    </HStack>
+  );
+}
+
+function FcDataAdvancedStatsSection({
+  stats,
+}: {
+  stats: FcDataAdvancedStats;
+}): React.JSX.Element | null {
+  if (stats.fingerprint.matchedRounds === 0) {
+    return null;
+  }
+
+  const topPirates = stats.pirateExposure.slice(0, MAX_EXPOSURE_ROWS);
+  const maxRate = Math.max(...topPirates.map(p => p.roundParticipationRate), 0.01);
+  const maxArenaRate = Math.max(...stats.arenaUsage.map(a => a.lineParticipationRate), 0.01);
+  const shapeTotal = stats.betShapes.total;
+
+  return (
+    <SectionCard title="Advanced Stats (from round history)">
+      <Text fontSize="xs" color="fg.muted">
+        Decoded from {stats.fingerprint.matchedRounds.toLocaleString()} round
+        {stats.fingerprint.matchedRounds === 1 ? '' : 's'} matched against the round history feed
+        {stats.fingerprint.unmatchedRounds > 0
+          ? ` (${stats.fingerprint.unmatchedRounds.toLocaleString()} not found)`
+          : ''}
+        .
+      </Text>
+
+      <SimpleGrid columns={{ base: 2, md: 4 }} gap={4}>
+        <StatBlock
+          label="Avg pirates/line"
+          value={stats.fingerprint.averagePiratesPerLine.toFixed(2)}
+        />
+        <StatBlock
+          label="Avg unique pirates/round"
+          value={stats.fingerprint.averageUniquePiratesPerRound.toFixed(1)}
+        />
+        <StatBlock label="10-line rounds" value={displayPercent(stats.fingerprint.tenLineShare)} />
+        <StatBlock
+          label="Favorite anchor"
+          value={stats.favoriteAnchorPirate ? stats.favoriteAnchorPirate.name : '-'}
+          sub={
+            stats.favoriteAnchorPirate &&
+            `anchor in ${displayPercent(stats.favoriteAnchorPirate.share)} of rounds`
+          }
+        />
+      </SimpleGrid>
+
+      {topPirates.length > 0 && (
+        <Stack gap={2}>
+          <Text fontSize="sm" fontWeight="medium">
+            Most bet pirates:
+          </Text>
+          <Stack gap={1}>
+            {topPirates.map(pirate => (
+              <PirateExposureBar
+                key={pirate.pirateId}
+                name={pirate.name}
+                rate={pirate.roundParticipationRate}
+                maxRate={maxRate}
+              />
+            ))}
+          </Stack>
+          <Text fontSize="xs" color="fg.muted" fontStyle="italic">
+            Share of matched rounds where the pirate appeared in at least one active bet line.
+            &quot;Net when included&quot; isn&apos;t shown per-pirate since a round&apos;s total
+            units won can&apos;t be split between co-occurring pirates without knowing which line
+            actually won.
+          </Text>
+        </Stack>
+      )}
+
+      <Stack gap={2}>
+        <Text fontSize="sm" fontWeight="medium">
+          Arena usage:
+        </Text>
+        <Stack gap={1}>
+          {stats.arenaUsage.map(arena => (
+            <PirateExposureBar
+              key={arena.arenaIndex}
+              name={arena.name}
+              rate={arena.lineParticipationRate}
+              maxRate={maxArenaRate}
+            />
+          ))}
+        </Stack>
+      </Stack>
+
+      {shapeTotal > 0 && (
+        <Stack gap={2}>
+          <Text fontSize="sm" fontWeight="medium">
+            Bet shapes:
+          </Text>
+          <Text fontSize="sm" color="fg.muted">
+            Gambit-shaped {displayPercent(stats.betShapes.gambitShaped / shapeTotal)} ·
+            Tenbet-shaped {displayPercent(stats.betShapes.tenbetShaped / shapeTotal)} · Other{' '}
+            {displayPercent(stats.betShapes.other / shapeTotal)}
+          </Text>
+          <Text fontSize="xs" color="fg.muted" fontStyle="italic">
+            Gambit-shaped: every line is a subset of one fixed 5-pirate combo. Tenbet-shaped: one
+            pirate is held fixed across every line while the rest vary. Structural guesses only -
+            not based on which NeoBot command generated the bet.
+          </Text>
+        </Stack>
+      )}
+    </SectionCard>
   );
 }
 
@@ -409,8 +597,31 @@ export function FcDataModal({ isOpen, onClose }: FcDataModalProps): React.JSX.El
   const months = React.useMemo(() => computeMonthlyStats(rows), [rows]);
   const cumulativeSeries = React.useMemo(() => computeCumulativeSeries(rows), [rows]);
   const roiSeries = React.useMemo(() => computeRoiSeries(rows), [rows]);
+  const returnDistribution = React.useMemo(() => computeReturnDistribution(rows), [rows]);
   const missedRoundGaps = React.useMemo(() => findMissedRoundGaps(rows), [rows]);
   const rowsByRound = React.useMemo(() => new Map(rows.map(row => [row.round, row])), [rows]);
+
+  const [advancedStatsRequested, setAdvancedStatsRequested] = React.useState(false);
+  const feed = useBacktestPreviousRounds({ enabled: advancedStatsRequested });
+  const [advancedStats, setAdvancedStats] = React.useState<FcDataAdvancedStats | null>(null);
+  const lastComputedRef = React.useRef<{ rows: FcDataRow[]; newestRound: number } | null>(null);
+
+  React.useEffect(() => {
+    if (feed.status !== 'ready') {
+      return;
+    }
+    const last = lastComputedRef.current;
+    if (last && last.rows === rows && last.newestRound === feed.newestRound) {
+      return;
+    }
+    const roundsByNumber = new Map(feed.rounds.map(r => [r.round, r]));
+    setAdvancedStats(computeAdvancedStats(rows, roundsByNumber));
+    lastComputedRef.current = { rows, newestRound: feed.newestRound };
+  }, [feed.status, feed.rounds, feed.newestRound, rows]);
+
+  const handleLoadAdvancedStats = React.useCallback((): void => {
+    setAdvancedStatsRequested(true);
+  }, []);
 
   return (
     <Dialog.Root
@@ -478,9 +689,49 @@ export function FcDataModal({ isOpen, onClose }: FcDataModalProps): React.JSX.El
                       </Button>
                     </HStack>
 
+                    {!advancedStatsRequested && (
+                      <HStack justify="space-between" flexWrap="wrap" gap={2}>
+                        <Text fontSize="xs" color="fg.muted">
+                          Pirate/arena exposure and bet-shape stats need the full round history
+                          (~13MB, cached).
+                        </Text>
+                        <Button size="xs" variant="outline" onClick={handleLoadAdvancedStats}>
+                          <FaChartBar />
+                          Load Detailed Stats
+                        </Button>
+                      </HStack>
+                    )}
+                    {advancedStatsRequested && feed.status === 'loading' && (
+                      <Text fontSize="xs" color="fg.muted">
+                        Downloading round history (~13MB)...
+                      </Text>
+                    )}
+                    {advancedStatsRequested && feed.status === 'error' && (
+                      <HStack justify="space-between" flexWrap="wrap" gap={2}>
+                        <Text fontSize="xs" color="fg.error">
+                          {feed.error ?? 'Failed to load round history.'}
+                        </Text>
+                        <Button size="xs" variant="outline" onClick={() => feed.refetch()}>
+                          Retry
+                        </Button>
+                      </HStack>
+                    )}
+                    {advancedStatsRequested && feed.status === 'ready' && (
+                      <HStack justify="space-between" flexWrap="wrap" gap={2}>
+                        <Text fontSize="xs" color="fg.muted">
+                          Round history loaded (newest #{feed.newestRound.toLocaleString()}).
+                        </Text>
+                        <Button size="xs" variant="outline" onClick={() => feed.refetch()}>
+                          Refresh round history
+                        </Button>
+                      </HStack>
+                    )}
+
                     <FcDataWarningsSection warnings={state.result.warnings} />
 
                     <FcDataTotalsSection totals={totals} />
+
+                    <FcDataReturnDistributionSection distribution={returnDistribution} />
 
                     <SimpleGrid columns={{ base: 1, md: 2 }} gap={3}>
                       <FcDataCumulativeChart series={cumulativeSeries} />
@@ -492,6 +743,8 @@ export function FcDataModal({ isOpen, onClose }: FcDataModalProps): React.JSX.El
                     <FcDataMonthlyTable months={months} />
 
                     <FcDataMissedRoundsSection gaps={missedRoundGaps} rowsByRound={rowsByRound} />
+
+                    {advancedStats && <FcDataAdvancedStatsSection stats={advancedStats} />}
                   </>
                 )}
               </Stack>

--- a/src/app/components/modals/FcDataModal.tsx
+++ b/src/app/components/modals/FcDataModal.tsx
@@ -167,6 +167,19 @@ function FcDataTotalsSection({ totals }: { totals: FcDataTotals }): React.JSX.El
           color="red.500"
         />
         <StatBlock
+          label="Current streak"
+          value={
+            totals.currentStreak
+              ? `${totals.currentStreak.count.toLocaleString()} ${totals.currentStreak.type === 'win' ? 'win' : 'bust'}${totals.currentStreak.count === 1 ? '' : 's'}`
+              : '-'
+          }
+          sub={
+            totals.currentStreak &&
+            formatDateRange(totals.currentStreak.startDate, totals.currentStreak.endDate)
+          }
+          color={totals.currentStreak?.type === 'win' ? 'green.600' : 'red.500'}
+        />
+        <StatBlock
           label="Best round"
           value={
             totals.bestRound ? (
@@ -435,11 +448,11 @@ function FcDataAdvancedStatsSection({
           value={stats.fingerprint.averageUniquePiratesPerRound.toFixed(1)}
         />
         <StatBlock
-          label="Favorite anchor"
+          label="Favorite anchor pirate"
           value={stats.favoriteAnchorPirate ? stats.favoriteAnchorPirate.name : '-'}
           sub={
             stats.favoriteAnchorPirate &&
-            `anchor in ${displayPercent(stats.favoriteAnchorPirate.share)} of rounds`
+            `in every line, ${displayPercent(stats.favoriteAnchorPirate.share)} of rounds`
           }
         />
       </SimpleGrid>
@@ -756,6 +769,8 @@ export function FcDataModal({ isOpen, onClose }: FcDataModalProps): React.JSX.El
                       </HStack>
                     )}
 
+                    {advancedStats && <FcDataAdvancedStatsSection stats={advancedStats} />}
+
                     <FcDataWarningsSection warnings={state.result.warnings} />
 
                     <FcDataTotalsSection totals={totals} />
@@ -778,8 +793,6 @@ export function FcDataModal({ isOpen, onClose }: FcDataModalProps): React.JSX.El
                       rowsByRound={rowsByRound}
                       isValidated={isFeedReady}
                     />
-
-                    {advancedStats && <FcDataAdvancedStatsSection stats={advancedStats} />}
                   </>
                 )}
               </Stack>

--- a/src/app/components/modals/FcDataModal.tsx
+++ b/src/app/components/modals/FcDataModal.tsx
@@ -2,6 +2,7 @@ import {
   Box,
   Button,
   CloseButton,
+  Code,
   Dialog,
   HStack,
   Link,
@@ -387,8 +388,9 @@ export function FcDataModal({ isOpen, onClose }: FcDataModalProps): React.JSX.El
             <Dialog.Body display="flex" flexDirection="column" overflowY="auto">
               <Stack gap={4}>
                 <Text fontSize="sm" color="fg.muted">
-                  Drop in a fc_data.csv export from NeoBot (the r/Neopets Discord bot) to see charts
-                  and stats about your personal NeoFoodClub betting history.
+                  Drop in a fc_data.csv export from NeoBot (the r/Neopets Discord bot's{' '}
+                  <Code fontSize="sm">?fcdata</Code> command) to see charts and stats about your
+                  personal NeoFoodClub betting history.
                 </Text>
 
                 <input

--- a/src/app/components/modals/FcDataModal.tsx
+++ b/src/app/components/modals/FcDataModal.tsx
@@ -18,7 +18,11 @@ import * as React from 'react';
 import { FaChartBar, FaFileCsv } from 'react-icons/fa';
 import { LuExternalLink } from 'react-icons/lu';
 
-import { computeAdvancedStats, type FcDataAdvancedStats } from '../../analysis/fcDataAdvancedStats';
+import {
+  computeAdvancedStats,
+  findMissedRoundGapsFromFeed,
+  type FcDataAdvancedStats,
+} from '../../analysis/fcDataAdvancedStats';
 import {
   computeBetShapeCounts,
   computeCumulativeSeries,
@@ -36,6 +40,7 @@ import {
 } from '../../analysis/fcDataStats';
 import { parseFcDataCsv, type FcDataParseResult, type FcDataRow } from '../../data/fcDataCsv';
 import { useBacktestPreviousRounds } from '../../hooks/useBacktestPreviousRounds';
+import { FcDataBetShapesChart } from '../charts/FcDataBetShapesChart';
 import { FcDataCumulativeChart } from '../charts/FcDataCumulativeChart';
 import { FcDataMonthlyBarChart } from '../charts/FcDataMonthlyBarChart';
 import { FcDataRoiChart } from '../charts/FcDataRoiChart';
@@ -293,9 +298,11 @@ function FcDataMonthlyTable({ months }: { months: FcDataMonthStats[] }): React.J
 function FcDataMissedRoundsSection({
   gaps,
   rowsByRound,
+  isValidated,
 }: {
   gaps: FcDataMissedRoundGap[];
   rowsByRound: Map<number, FcDataRow>;
+  isValidated: boolean;
 }): React.JSX.Element | null {
   if (gaps.length === 0) {
     return null;
@@ -307,6 +314,12 @@ function FcDataMissedRoundsSection({
         {gaps.length} gap{gaps.length === 1 ? '' : 's'} where one or more rounds weren&apos;t
         recorded
       </Text>
+      {!isValidated && (
+        <Text fontSize="xs" color="fg.muted" fontStyle="italic">
+          Based on round numbers only - some of these rounds may never have run. Load Detailed Stats
+          to check against the round history feed.
+        </Text>
+      )}
       <Stack gap={1} maxH="180px" overflowY="auto">
         {gaps.map(gap => {
           const afterUrl = rowsByRound.get(gap.afterRound)?.url;
@@ -421,7 +434,6 @@ function FcDataAdvancedStatsSection({
           label="Avg unique pirates/round"
           value={stats.fingerprint.averageUniquePiratesPerRound.toFixed(1)}
         />
-        <StatBlock label="10-line rounds" value={displayPercent(stats.fingerprint.tenLineShare)} />
         <StatBlock
           label="Favorite anchor"
           value={stats.favoriteAnchorPirate ? stats.favoriteAnchorPirate.name : '-'}
@@ -475,14 +487,6 @@ function FcDataAdvancedStatsSection({
   );
 }
 
-const BET_SHAPE_LABELS: { key: keyof FcDataBetShapeCounts; label: string }[] = [
-  { key: 'gambitShaped', label: 'Gambit-shaped' },
-  { key: 'bustproofShaped', label: 'Bustproof-shaped' },
-  { key: 'crazyShaped', label: 'Crazy-shaped' },
-  { key: 'tenbetShaped', label: 'Tenbet-shaped' },
-  { key: 'other', label: 'Other' },
-];
-
 function FcDataBetShapesSection({
   shapes,
 }: {
@@ -494,11 +498,7 @@ function FcDataBetShapesSection({
 
   return (
     <SectionCard title="Bet Shapes">
-      <Text fontSize="sm" color="fg.muted">
-        {BET_SHAPE_LABELS.map(
-          ({ key, label }) => `${label} ${displayPercent(shapes[key] / shapes.total)}`,
-        ).join(' · ')}
-      </Text>
+      <FcDataBetShapesChart shapes={shapes} />
       <Text fontSize="xs" color="fg.muted" fontStyle="italic">
         Gambit-shaped: every line is a subset of one fixed 5-pirate combo. Bustproof-shaped: some
         arena has all 4 of its pirates covered. Crazy-shaped: every line picks a pirate in all 5
@@ -617,11 +617,24 @@ export function FcDataModal({ isOpen, onClose }: FcDataModalProps): React.JSX.El
   const roiSeries = React.useMemo(() => computeRoiSeries(rows), [rows]);
   const returnDistribution = React.useMemo(() => computeReturnDistribution(rows), [rows]);
   const betShapeCounts = React.useMemo(() => computeBetShapeCounts(rows), [rows]);
-  const missedRoundGaps = React.useMemo(() => findMissedRoundGaps(rows), [rows]);
   const rowsByRound = React.useMemo(() => new Map(rows.map(row => [row.round, row])), [rows]);
 
   const [advancedStatsRequested, setAdvancedStatsRequested] = React.useState(false);
   const feed = useBacktestPreviousRounds({ enabled: advancedStatsRequested });
+  const feedRoundsByNumber = React.useMemo(
+    () => new Map(feed.rounds.map(r => [r.round, r])),
+    [feed.rounds],
+  );
+  const isFeedReady = feed.status === 'ready' && feedRoundsByNumber.size > 0;
+
+  const missedRoundGaps = React.useMemo(
+    () =>
+      isFeedReady
+        ? findMissedRoundGapsFromFeed(rows, feedRoundsByNumber)
+        : findMissedRoundGaps(rows),
+    [rows, isFeedReady, feedRoundsByNumber],
+  );
+
   const [advancedStats, setAdvancedStats] = React.useState<FcDataAdvancedStats | null>(null);
   const lastComputedRef = React.useRef<{ rows: FcDataRow[]; newestRound: number } | null>(null);
 
@@ -633,10 +646,9 @@ export function FcDataModal({ isOpen, onClose }: FcDataModalProps): React.JSX.El
     if (last && last.rows === rows && last.newestRound === feed.newestRound) {
       return;
     }
-    const roundsByNumber = new Map(feed.rounds.map(r => [r.round, r]));
-    setAdvancedStats(computeAdvancedStats(rows, roundsByNumber));
+    setAdvancedStats(computeAdvancedStats(rows, feedRoundsByNumber));
     lastComputedRef.current = { rows, newestRound: feed.newestRound };
-  }, [feed.status, feed.rounds, feed.newestRound, rows]);
+  }, [feed.status, feed.newestRound, rows, feedRoundsByNumber]);
 
   const handleLoadAdvancedStats = React.useCallback((): void => {
     setAdvancedStatsRequested(true);
@@ -665,7 +677,8 @@ export function FcDataModal({ isOpen, onClose }: FcDataModalProps): React.JSX.El
                 <Text fontSize="sm" color="fg.muted">
                   Drop in a fc_data.csv export from NeoBot (the r/Neopets Discord bot's{' '}
                   <Code fontSize="sm">?fcdata</Code> command) to see charts and stats about your
-                  personal NeoFoodClub betting history.
+                  personal NeoFoodClub betting history. Everything is processed locally in your
+                  browser - your file is never uploaded anywhere.
                 </Text>
 
                 <input
@@ -763,7 +776,11 @@ export function FcDataModal({ isOpen, onClose }: FcDataModalProps): React.JSX.El
 
                     <FcDataMonthlyTable months={months} />
 
-                    <FcDataMissedRoundsSection gaps={missedRoundGaps} rowsByRound={rowsByRound} />
+                    <FcDataMissedRoundsSection
+                      gaps={missedRoundGaps}
+                      rowsByRound={rowsByRound}
+                      isValidated={isFeedReady}
+                    />
 
                     {advancedStats && <FcDataAdvancedStatsSection stats={advancedStats} />}
                   </>

--- a/src/app/components/modals/FcDataModal.tsx
+++ b/src/app/components/modals/FcDataModal.tsx
@@ -1,13 +1,13 @@
 import {
   Box,
   Button,
+  Card,
   CloseButton,
   Code,
   Dialog,
   HStack,
   Link,
   Portal,
-  Progress,
   SimpleGrid,
   Stack,
   Table,
@@ -19,11 +19,9 @@ import { FaFileCsv } from 'react-icons/fa';
 
 import {
   computeCumulativeSeries,
-  computeDayOfWeekStats,
   computeMonthlyStats,
   computeTotals,
   findMissedRoundGaps,
-  type FcDataDayOfWeekStats,
   type FcDataMissedRoundGap,
   type FcDataMonthStats,
   type FcDataTotals,
@@ -50,58 +48,137 @@ function displayPercent(value: number): string {
   return `${(value * 100).toFixed(1)}%`;
 }
 
-function StatBlock({ label, value }: { label: string; value: React.ReactNode }): React.JSX.Element {
+function formatRoi(value: number): string {
+  return `${value.toFixed(2)}x`;
+}
+
+function roiColor(value: number): string {
+  return value >= 1 ? 'green.600' : 'orange.500';
+}
+
+function formatDateRange(start: Date, end: Date): string {
+  const startLabel = format(start, 'MMM d, yyyy');
+  if (start.getTime() === end.getTime()) {
+    return startLabel;
+  }
+  return `${startLabel} - ${format(end, 'MMM d, yyyy')}`;
+}
+
+function SectionCard({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}): React.JSX.Element {
+  return (
+    <Card.Root boxShadow="sm">
+      <Card.Body p={4}>
+        <Stack gap={3}>
+          <Text fontSize="sm" fontWeight="semibold" color="fg.muted" letterSpacing="wide">
+            {title.toUpperCase()}
+          </Text>
+          {children}
+        </Stack>
+      </Card.Body>
+    </Card.Root>
+  );
+}
+
+function StatBlock({
+  label,
+  value,
+  sub,
+  color,
+}: {
+  label: string;
+  value: React.ReactNode;
+  sub?: React.ReactNode;
+  color?: string;
+}): React.JSX.Element {
   return (
     <Stack gap={0}>
       <Text fontSize="xs" color="fg.muted">
         {label}
       </Text>
-      <Text fontSize="lg" fontWeight="semibold">
+      <Text fontSize="lg" fontWeight="semibold" color={color}>
         {value}
       </Text>
+      {sub && (
+        <Text fontSize="xs" color="fg.muted">
+          {sub}
+        </Text>
+      )}
     </Stack>
   );
 }
 
 function FcDataTotalsSection({ totals }: { totals: FcDataTotals }): React.JSX.Element {
   return (
-    <SimpleGrid columns={{ base: 2, md: 4 }} gap={4}>
-      <StatBlock label="Rounds recorded" value={totals.roundsRecorded.toLocaleString()} />
-      <StatBlock label="Total units won" value={formatUnits(totals.totalUnitsWon)} />
-      <StatBlock label="Average per round" value={totals.averageUnitsPerRound.toFixed(1)} />
-      <StatBlock label="Win rate" value={displayPercent(totals.winRate)} />
-      <StatBlock label="Longest win streak" value={totals.longestWinStreak.toLocaleString()} />
-      <StatBlock label="Longest loss streak" value={totals.longestLossStreak.toLocaleString()} />
-      <StatBlock
-        label="Best round"
-        value={
-          totals.bestRound ? (
-            <Link href={totals.bestRound.url} target="_blank" fontSize="lg">
-              #{totals.bestRound.round} ({formatUnits(totals.bestRound.unitsWon)})
-            </Link>
-          ) : (
-            '-'
-          )
-        }
-      />
-      <StatBlock
-        label="Date range"
-        value={
-          totals.firstRound && totals.lastRound
-            ? `${format(totals.firstRound.date, 'MMM d, yyyy')} - ${format(totals.lastRound.date, 'MMM d, yyyy')}`
-            : '-'
-        }
-      />
-    </SimpleGrid>
+    <SectionCard title="Overview">
+      <SimpleGrid columns={{ base: 2, md: 4 }} gap={4}>
+        <StatBlock label="Rounds recorded" value={totals.roundsRecorded.toLocaleString()} />
+        <StatBlock
+          label="Total units won"
+          value={formatUnits(totals.totalUnitsWon)}
+          color="nfc-blue.600"
+        />
+        <StatBlock label="Average per round" value={totals.averageUnitsPerRound.toFixed(1)} />
+        <StatBlock
+          label="Win rate"
+          value={displayPercent(totals.winRate)}
+          color={totals.winRate >= 0.5 ? 'green.600' : 'orange.500'}
+        />
+        <StatBlock
+          label="Longest win streak"
+          value={
+            totals.longestWinStreak
+              ? `${totals.longestWinStreak.count.toLocaleString()} (${formatUnits(totals.longestWinStreak.totalUnitsWon)} units)`
+              : '-'
+          }
+          sub={
+            totals.longestWinStreak &&
+            formatDateRange(totals.longestWinStreak.startDate, totals.longestWinStreak.endDate)
+          }
+          color="green.600"
+        />
+        <StatBlock
+          label="Longest bust streak"
+          value={totals.longestLossStreak ? totals.longestLossStreak.count.toLocaleString() : '-'}
+          sub={
+            totals.longestLossStreak &&
+            formatDateRange(totals.longestLossStreak.startDate, totals.longestLossStreak.endDate)
+          }
+          color="red.500"
+        />
+        <StatBlock
+          label="Best round"
+          value={
+            totals.bestRound ? (
+              <Link href={totals.bestRound.url} target="_blank" fontSize="lg">
+                #{totals.bestRound.round} ({formatUnits(totals.bestRound.unitsWon)})
+              </Link>
+            ) : (
+              '-'
+            )
+          }
+        />
+        <StatBlock
+          label="Date range"
+          value={
+            totals.firstRound && totals.lastRound
+              ? `${format(totals.firstRound.date, 'MMM d, yyyy')} - ${format(totals.lastRound.date, 'MMM d, yyyy')}`
+              : '-'
+          }
+        />
+      </SimpleGrid>
+    </SectionCard>
   );
 }
 
 function FcDataMonthlyTable({ months }: { months: FcDataMonthStats[] }): React.JSX.Element {
   return (
-    <Stack gap={2}>
-      <Text fontSize="sm" fontWeight="medium">
-        Per-month breakdown:
-      </Text>
+    <SectionCard title="Per-Month Breakdown">
       <Box maxH="280px" overflowY="auto">
         <Table.Root size="sm" width="full">
           <Table.Header>
@@ -111,6 +188,8 @@ function FcDataMonthlyTable({ months }: { months: FcDataMonthStats[] }): React.J
               <Table.ColumnHeader textAlign="right">Total Won</Table.ColumnHeader>
               <Table.ColumnHeader textAlign="right">Avg/Round</Table.ColumnHeader>
               <Table.ColumnHeader textAlign="right">Win Rate</Table.ColumnHeader>
+              <Table.ColumnHeader textAlign="right">ROI</Table.ColumnHeader>
+              <Table.ColumnHeader textAlign="right">Running ROI</Table.ColumnHeader>
               <Table.ColumnHeader textAlign="right">Best Round</Table.ColumnHeader>
             </Table.Row>
           </Table.Header>
@@ -122,6 +201,12 @@ function FcDataMonthlyTable({ months }: { months: FcDataMonthStats[] }): React.J
                 <Table.Cell textAlign="right">{formatUnits(month.totalUnitsWon)}</Table.Cell>
                 <Table.Cell textAlign="right">{month.averageUnitsPerRound.toFixed(1)}</Table.Cell>
                 <Table.Cell textAlign="right">{displayPercent(month.winRate)}</Table.Cell>
+                <Table.Cell textAlign="right" color={roiColor(month.roi)} fontWeight="medium">
+                  {formatRoi(month.roi)}
+                </Table.Cell>
+                <Table.Cell textAlign="right" color={roiColor(month.cumulativeRoi)}>
+                  {formatRoi(month.cumulativeRoi)}
+                </Table.Cell>
                 <Table.Cell textAlign="right">
                   {month.bestRound && (
                     <Link href={month.bestRound.url} target="_blank" fontSize="sm">
@@ -134,49 +219,12 @@ function FcDataMonthlyTable({ months }: { months: FcDataMonthStats[] }): React.J
           </Table.Body>
         </Table.Root>
       </Box>
-    </Stack>
-  );
-}
-
-function FcDataDayOfWeekSection({ days }: { days: FcDataDayOfWeekStats[] }): React.JSX.Element {
-  const maxAverage = Math.max(...days.map(day => day.averageUnitsPerRound), 1);
-
-  return (
-    <Stack gap={2}>
-      <Text fontSize="sm" fontWeight="medium">
-        By day of week:
+      <Text fontSize="xs" color="fg.muted" fontStyle="italic">
+        ROI is units won per active bet line (not real NP wagered - the CSV has no bet amounts),
+        where 1.00x means breaking even. Running ROI accumulates from the first recorded round
+        through the end of that month.
       </Text>
-      <Table.Root size="sm" width="full">
-        <Table.Header>
-          <Table.Row>
-            <Table.ColumnHeader width="60px">Day</Table.ColumnHeader>
-            <Table.ColumnHeader textAlign="right">Rounds</Table.ColumnHeader>
-            <Table.ColumnHeader textAlign="right">Avg/Round</Table.ColumnHeader>
-            <Table.ColumnHeader width="40%" />
-          </Table.Row>
-        </Table.Header>
-        <Table.Body>
-          {days.map(day => (
-            <Table.Row key={day.dayOfWeek}>
-              <Table.Cell>{day.label}</Table.Cell>
-              <Table.Cell textAlign="right">{day.roundsPlayed.toLocaleString()}</Table.Cell>
-              <Table.Cell textAlign="right">{day.averageUnitsPerRound.toFixed(1)}</Table.Cell>
-              <Table.Cell p={2}>
-                <Progress.Root
-                  value={(day.averageUnitsPerRound / maxAverage) * 100}
-                  size="xs"
-                  colorPalette="nfc-blue"
-                >
-                  <Progress.Track>
-                    <Progress.Range />
-                  </Progress.Track>
-                </Progress.Root>
-              </Table.Cell>
-            </Table.Row>
-          ))}
-        </Table.Body>
-      </Table.Root>
-    </Stack>
+    </SectionCard>
   );
 }
 
@@ -192,16 +240,11 @@ function FcDataMissedRoundsSection({
   }
 
   return (
-    <Stack gap={2}>
-      <HStack>
-        <Text fontSize="sm" fontWeight="medium">
-          Missed rounds:
-        </Text>
-        <Text fontSize="sm" color="fg.muted">
-          {gaps.length} gap{gaps.length === 1 ? '' : 's'} where one or more rounds weren&apos;t
-          recorded
-        </Text>
-      </HStack>
+    <SectionCard title="Missed Rounds">
+      <Text fontSize="sm" color="fg.muted">
+        {gaps.length} gap{gaps.length === 1 ? '' : 's'} where one or more rounds weren&apos;t
+        recorded
+      </Text>
       <Stack gap={1} maxH="180px" overflowY="auto">
         {gaps.map(gap => {
           const afterUrl = rowsByRound.get(gap.afterRound)?.url;
@@ -228,7 +271,7 @@ function FcDataMissedRoundsSection({
           );
         })}
       </Stack>
-    </Stack>
+    </SectionCard>
   );
 }
 
@@ -363,7 +406,6 @@ export function FcDataModal({ isOpen, onClose }: FcDataModalProps): React.JSX.El
   const totals = React.useMemo(() => computeTotals(rows), [rows]);
   const months = React.useMemo(() => computeMonthlyStats(rows), [rows]);
   const cumulativeSeries = React.useMemo(() => computeCumulativeSeries(rows), [rows]);
-  const dayOfWeekStats = React.useMemo(() => computeDayOfWeekStats(rows), [rows]);
   const missedRoundGaps = React.useMemo(() => findMissedRoundGaps(rows), [rows]);
   const rowsByRound = React.useMemo(() => new Map(rows.map(row => [row.round, row])), [rows]);
 
@@ -437,13 +479,12 @@ export function FcDataModal({ isOpen, onClose }: FcDataModalProps): React.JSX.El
 
                     <FcDataTotalsSection totals={totals} />
 
-                    <FcDataCumulativeChart series={cumulativeSeries} />
-
-                    <FcDataMonthlyBarChart months={months} />
+                    <SimpleGrid columns={{ base: 1, md: 2 }} gap={3}>
+                      <FcDataCumulativeChart series={cumulativeSeries} />
+                      <FcDataMonthlyBarChart months={months} />
+                    </SimpleGrid>
 
                     <FcDataMonthlyTable months={months} />
-
-                    <FcDataDayOfWeekSection days={dayOfWeekStats} />
 
                     <FcDataMissedRoundsSection gaps={missedRoundGaps} rowsByRound={rowsByRound} />
                   </>

--- a/src/app/components/modals/FcDataModal.tsx
+++ b/src/app/components/modals/FcDataModal.tsx
@@ -1,0 +1,461 @@
+import {
+  Box,
+  Button,
+  CloseButton,
+  Dialog,
+  HStack,
+  Link,
+  Portal,
+  Progress,
+  SimpleGrid,
+  Stack,
+  Table,
+  Text,
+} from '@chakra-ui/react';
+import { format } from 'date-fns';
+import * as React from 'react';
+import { FaFileCsv } from 'react-icons/fa';
+
+import {
+  computeCumulativeSeries,
+  computeDayOfWeekStats,
+  computeMonthlyStats,
+  computeTotals,
+  findMissedRoundGaps,
+  type FcDataDayOfWeekStats,
+  type FcDataMissedRoundGap,
+  type FcDataMonthStats,
+  type FcDataTotals,
+} from '../../analysis/fcDataStats';
+import { parseFcDataCsv, type FcDataParseResult, type FcDataRow } from '../../data/fcDataCsv';
+import { FcDataCumulativeChart } from '../charts/FcDataCumulativeChart';
+import { FcDataMonthlyBarChart } from '../charts/FcDataMonthlyBarChart';
+
+interface FcDataModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+type FcDataLoadState =
+  | { status: 'empty' }
+  | { status: 'loaded'; fileName: string; result: FcDataParseResult }
+  | { status: 'error'; fileName: string; message: string };
+
+function formatUnits(value: number): string {
+  return Math.round(value).toLocaleString();
+}
+
+function displayPercent(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function StatBlock({ label, value }: { label: string; value: React.ReactNode }): React.JSX.Element {
+  return (
+    <Stack gap={0}>
+      <Text fontSize="xs" color="fg.muted">
+        {label}
+      </Text>
+      <Text fontSize="lg" fontWeight="semibold">
+        {value}
+      </Text>
+    </Stack>
+  );
+}
+
+function FcDataTotalsSection({ totals }: { totals: FcDataTotals }): React.JSX.Element {
+  return (
+    <SimpleGrid columns={{ base: 2, md: 4 }} gap={4}>
+      <StatBlock label="Rounds recorded" value={totals.roundsRecorded.toLocaleString()} />
+      <StatBlock label="Total units won" value={formatUnits(totals.totalUnitsWon)} />
+      <StatBlock label="Average per round" value={totals.averageUnitsPerRound.toFixed(1)} />
+      <StatBlock label="Win rate" value={displayPercent(totals.winRate)} />
+      <StatBlock label="Longest win streak" value={totals.longestWinStreak.toLocaleString()} />
+      <StatBlock label="Longest loss streak" value={totals.longestLossStreak.toLocaleString()} />
+      <StatBlock
+        label="Best round"
+        value={
+          totals.bestRound ? (
+            <Link href={totals.bestRound.url} target="_blank" fontSize="lg">
+              #{totals.bestRound.round} ({formatUnits(totals.bestRound.unitsWon)})
+            </Link>
+          ) : (
+            '-'
+          )
+        }
+      />
+      <StatBlock
+        label="Date range"
+        value={
+          totals.firstRound && totals.lastRound
+            ? `${format(totals.firstRound.date, 'MMM d, yyyy')} - ${format(totals.lastRound.date, 'MMM d, yyyy')}`
+            : '-'
+        }
+      />
+    </SimpleGrid>
+  );
+}
+
+function FcDataMonthlyTable({ months }: { months: FcDataMonthStats[] }): React.JSX.Element {
+  return (
+    <Stack gap={2}>
+      <Text fontSize="sm" fontWeight="medium">
+        Per-month breakdown:
+      </Text>
+      <Box maxH="280px" overflowY="auto">
+        <Table.Root size="sm" width="full">
+          <Table.Header>
+            <Table.Row>
+              <Table.ColumnHeader>Month</Table.ColumnHeader>
+              <Table.ColumnHeader textAlign="right">Rounds</Table.ColumnHeader>
+              <Table.ColumnHeader textAlign="right">Total Won</Table.ColumnHeader>
+              <Table.ColumnHeader textAlign="right">Avg/Round</Table.ColumnHeader>
+              <Table.ColumnHeader textAlign="right">Win Rate</Table.ColumnHeader>
+              <Table.ColumnHeader textAlign="right">Best Round</Table.ColumnHeader>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {months.map(month => (
+              <Table.Row key={month.monthKey}>
+                <Table.Cell>{month.label}</Table.Cell>
+                <Table.Cell textAlign="right">{month.roundsPlayed.toLocaleString()}</Table.Cell>
+                <Table.Cell textAlign="right">{formatUnits(month.totalUnitsWon)}</Table.Cell>
+                <Table.Cell textAlign="right">{month.averageUnitsPerRound.toFixed(1)}</Table.Cell>
+                <Table.Cell textAlign="right">{displayPercent(month.winRate)}</Table.Cell>
+                <Table.Cell textAlign="right">
+                  {month.bestRound && (
+                    <Link href={month.bestRound.url} target="_blank" fontSize="sm">
+                      #{month.bestRound.round} ({formatUnits(month.bestRound.unitsWon)})
+                    </Link>
+                  )}
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table.Root>
+      </Box>
+    </Stack>
+  );
+}
+
+function FcDataDayOfWeekSection({ days }: { days: FcDataDayOfWeekStats[] }): React.JSX.Element {
+  const maxAverage = Math.max(...days.map(day => day.averageUnitsPerRound), 1);
+
+  return (
+    <Stack gap={2}>
+      <Text fontSize="sm" fontWeight="medium">
+        By day of week:
+      </Text>
+      <Table.Root size="sm" width="full">
+        <Table.Header>
+          <Table.Row>
+            <Table.ColumnHeader width="60px">Day</Table.ColumnHeader>
+            <Table.ColumnHeader textAlign="right">Rounds</Table.ColumnHeader>
+            <Table.ColumnHeader textAlign="right">Avg/Round</Table.ColumnHeader>
+            <Table.ColumnHeader width="40%" />
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {days.map(day => (
+            <Table.Row key={day.dayOfWeek}>
+              <Table.Cell>{day.label}</Table.Cell>
+              <Table.Cell textAlign="right">{day.roundsPlayed.toLocaleString()}</Table.Cell>
+              <Table.Cell textAlign="right">{day.averageUnitsPerRound.toFixed(1)}</Table.Cell>
+              <Table.Cell p={2}>
+                <Progress.Root
+                  value={(day.averageUnitsPerRound / maxAverage) * 100}
+                  size="xs"
+                  colorPalette="nfc-blue"
+                >
+                  <Progress.Track>
+                    <Progress.Range />
+                  </Progress.Track>
+                </Progress.Root>
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table.Root>
+    </Stack>
+  );
+}
+
+function FcDataMissedRoundsSection({
+  gaps,
+  rowsByRound,
+}: {
+  gaps: FcDataMissedRoundGap[];
+  rowsByRound: Map<number, FcDataRow>;
+}): React.JSX.Element | null {
+  if (gaps.length === 0) {
+    return null;
+  }
+
+  return (
+    <Stack gap={2}>
+      <HStack>
+        <Text fontSize="sm" fontWeight="medium">
+          Missed rounds:
+        </Text>
+        <Text fontSize="sm" color="fg.muted">
+          {gaps.length} gap{gaps.length === 1 ? '' : 's'} where one or more rounds weren&apos;t
+          recorded
+        </Text>
+      </HStack>
+      <Stack gap={1} maxH="180px" overflowY="auto">
+        {gaps.map(gap => {
+          const afterUrl = rowsByRound.get(gap.afterRound)?.url;
+          const beforeUrl = rowsByRound.get(gap.beforeRound)?.url;
+          return (
+            <Text key={`${gap.afterRound}-${gap.beforeRound}`} fontSize="sm" color="fg.muted">
+              {gap.missingCount} round{gap.missingCount === 1 ? '' : 's'} missed between{' '}
+              {afterUrl ? (
+                <Link href={afterUrl} target="_blank" fontSize="sm">
+                  #{gap.afterRound}
+                </Link>
+              ) : (
+                `#${gap.afterRound}`
+              )}{' '}
+              and{' '}
+              {beforeUrl ? (
+                <Link href={beforeUrl} target="_blank" fontSize="sm">
+                  #{gap.beforeRound}
+                </Link>
+              ) : (
+                `#${gap.beforeRound}`
+              )}
+            </Text>
+          );
+        })}
+      </Stack>
+    </Stack>
+  );
+}
+
+function FcDataWarningsSection({
+  warnings,
+}: {
+  warnings: FcDataParseResult['warnings'];
+}): React.JSX.Element | null {
+  if (warnings.length === 0) {
+    return null;
+  }
+
+  return (
+    <Stack gap={1}>
+      <Text fontSize="xs" color="fg.muted">
+        {warnings.length} row{warnings.length === 1 ? '' : 's'} skipped while parsing:
+      </Text>
+      <Stack gap={0} maxH="100px" overflowY="auto">
+        {warnings.map(warning => (
+          <Text key={warning.line} fontSize="xs" color="fg.muted" fontFamily="mono">
+            line {warning.line}: {warning.reason}
+          </Text>
+        ))}
+      </Stack>
+    </Stack>
+  );
+}
+
+function DropZone({
+  isDragOver,
+  onDrop,
+  onDragOver,
+  onDragLeave,
+  onBrowseClick,
+}: {
+  isDragOver: boolean;
+  onDrop: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDragOver: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDragLeave: () => void;
+  onBrowseClick: () => void;
+}): React.JSX.Element {
+  return (
+    <Box
+      borderWidth="2px"
+      borderStyle="dashed"
+      borderColor={isDragOver ? 'nfc-blue.500' : 'border'}
+      bg={isDragOver ? 'nfc-blue.50' : undefined}
+      borderRadius="md"
+      p={8}
+      textAlign="center"
+      onDrop={onDrop}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+    >
+      <Stack gap={3} align="center">
+        <FaFileCsv size={32} />
+        <Text fontSize="sm" color="fg.muted">
+          Drag and drop your fc_data.csv file here
+        </Text>
+        <Button size="sm" variant="outline" onClick={onBrowseClick}>
+          Browse...
+        </Button>
+      </Stack>
+    </Box>
+  );
+}
+
+export function FcDataModal({ isOpen, onClose }: FcDataModalProps): React.JSX.Element {
+  const [state, setState] = React.useState<FcDataLoadState>({ status: 'empty' });
+  const [isDragOver, setIsDragOver] = React.useState(false);
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
+
+  const loadFile = React.useCallback((file: File): void => {
+    const reader = new FileReader();
+    reader.onload = (): void => {
+      const text = typeof reader.result === 'string' ? reader.result : '';
+      const result = parseFcDataCsv(text);
+      if (result.rows.length === 0) {
+        setState({ status: 'error', fileName: file.name, message: 'No valid rows found in file.' });
+        return;
+      }
+      setState({ status: 'loaded', fileName: file.name, result });
+    };
+    reader.onerror = (): void => {
+      setState({ status: 'error', fileName: file.name, message: 'Failed to read file.' });
+    };
+    reader.readAsText(file);
+  }, []);
+
+  const handleDrop = React.useCallback(
+    (e: React.DragEvent<HTMLDivElement>): void => {
+      e.preventDefault();
+      setIsDragOver(false);
+      const file = e.dataTransfer.files[0];
+      if (file) {
+        loadFile(file);
+      }
+    },
+    [loadFile],
+  );
+
+  const handleDragOver = React.useCallback((e: React.DragEvent<HTMLDivElement>): void => {
+    e.preventDefault();
+    setIsDragOver(true);
+  }, []);
+
+  const handleDragLeave = React.useCallback((): void => {
+    setIsDragOver(false);
+  }, []);
+
+  const handleBrowseClick = React.useCallback((): void => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleFileInputChange = React.useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>): void => {
+      const file = e.target.files?.[0];
+      if (file) {
+        loadFile(file);
+      }
+      e.target.value = '';
+    },
+    [loadFile],
+  );
+
+  const handleLoadAnother = React.useCallback((): void => {
+    setState({ status: 'empty' });
+  }, []);
+
+  const rows = React.useMemo(() => (state.status === 'loaded' ? state.result.rows : []), [state]);
+
+  const totals = React.useMemo(() => computeTotals(rows), [rows]);
+  const months = React.useMemo(() => computeMonthlyStats(rows), [rows]);
+  const cumulativeSeries = React.useMemo(() => computeCumulativeSeries(rows), [rows]);
+  const dayOfWeekStats = React.useMemo(() => computeDayOfWeekStats(rows), [rows]);
+  const missedRoundGaps = React.useMemo(() => findMissedRoundGaps(rows), [rows]);
+  const rowsByRound = React.useMemo(() => new Map(rows.map(row => [row.round, row])), [rows]);
+
+  return (
+    <Dialog.Root
+      open={isOpen}
+      onOpenChange={(e: { open: boolean }) => !e.open && onClose()}
+      size="cover"
+      preventScroll
+      modal
+    >
+      <Portal>
+        <Dialog.Backdrop />
+        <Dialog.Positioner>
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>FC Data Import</Dialog.Title>
+              <Dialog.CloseTrigger asChild>
+                <CloseButton size="sm" />
+              </Dialog.CloseTrigger>
+            </Dialog.Header>
+            <Dialog.Body display="flex" flexDirection="column" overflowY="auto">
+              <Stack gap={4}>
+                <Text fontSize="sm" color="fg.muted">
+                  Drop in a fc_data.csv export from NeoBot (the r/Neopets Discord bot) to see charts
+                  and stats about your personal NeoFoodClub betting history.
+                </Text>
+
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".csv"
+                  hidden
+                  onChange={handleFileInputChange}
+                />
+
+                {state.status !== 'loaded' && (
+                  <DropZone
+                    isDragOver={isDragOver}
+                    onDrop={handleDrop}
+                    onDragOver={handleDragOver}
+                    onDragLeave={handleDragLeave}
+                    onBrowseClick={handleBrowseClick}
+                  />
+                )}
+
+                {state.status === 'error' && (
+                  <Text fontSize="sm" color="fg.error">
+                    {state.fileName}: {state.message}
+                  </Text>
+                )}
+
+                {state.status === 'loaded' && (
+                  <>
+                    <HStack justify="space-between" flexWrap="wrap" gap={2}>
+                      <Text fontSize="sm" color="fg.muted">
+                        {state.fileName}: {rows.length.toLocaleString()} round
+                        {rows.length === 1 ? '' : 's'} loaded
+                        {state.result.warnings.length > 0
+                          ? ` (${state.result.warnings.length} skipped)`
+                          : ''}
+                        .
+                      </Text>
+                      <Button size="xs" variant="outline" onClick={handleLoadAnother}>
+                        Load another file
+                      </Button>
+                    </HStack>
+
+                    <FcDataWarningsSection warnings={state.result.warnings} />
+
+                    <FcDataTotalsSection totals={totals} />
+
+                    <FcDataCumulativeChart series={cumulativeSeries} />
+
+                    <FcDataMonthlyBarChart months={months} />
+
+                    <FcDataMonthlyTable months={months} />
+
+                    <FcDataDayOfWeekSection days={dayOfWeekStats} />
+
+                    <FcDataMissedRoundsSection gaps={missedRoundGaps} rowsByRound={rowsByRound} />
+                  </>
+                )}
+              </Stack>
+            </Dialog.Body>
+            <Dialog.Footer>
+              <Button variant="outline" onClick={onClose}>
+                Close
+              </Button>
+            </Dialog.Footer>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/app/components/modals/FcDataModal.tsx
+++ b/src/app/components/modals/FcDataModal.tsx
@@ -12,10 +12,22 @@ import {
   Stack,
   Table,
   Text,
+  useClipboard,
 } from '@chakra-ui/react';
 import { format } from 'date-fns';
 import * as React from 'react';
-import { FaChartBar, FaFileCsv } from 'react-icons/fa';
+import {
+  FaCalendar,
+  FaChartBar,
+  FaChartPie,
+  FaCheck,
+  FaClipboardList,
+  FaCopy,
+  FaFileCsv,
+  FaShapes,
+  FaTrophy,
+} from 'react-icons/fa';
+import { FaCalendarDays, FaMagnifyingGlassChart, FaTriangleExclamation } from 'react-icons/fa6';
 import { LuExternalLink } from 'react-icons/lu';
 
 import {
@@ -24,19 +36,26 @@ import {
   type FcDataAdvancedStats,
 } from '../../analysis/fcDataAdvancedStats';
 import {
+  buildShareSummary,
   computeBetShapeCounts,
   computeCumulativeSeries,
   computeMonthlyStats,
   computeReturnDistribution,
   computeRoiSeries,
+  computeRollingRoiSeries,
   computeTotals,
+  computeYearlyStats,
+  findBestAndWorstMonth,
   findMissedRoundGaps,
+  ROLLING_ROI_WINDOW,
   type FcDataBetShapeCounts,
   type FcDataMissedRoundGap,
+  type FcDataMonthHighlight,
   type FcDataMonthStats,
   type FcDataReturnBucket,
   type FcDataReturnDistribution,
   type FcDataTotals,
+  type FcDataYearStats,
 } from '../../analysis/fcDataStats';
 import { parseFcDataCsv, type FcDataParseResult, type FcDataRow } from '../../data/fcDataCsv';
 import { useBacktestPreviousRounds } from '../../hooks/useBacktestPreviousRounds';
@@ -81,18 +100,27 @@ function formatDateRange(start: Date, end: Date): string {
 
 function SectionCard({
   title,
+  icon: IconComponent,
   children,
 }: {
   title: string;
+  icon?: React.ComponentType;
   children: React.ReactNode;
 }): React.JSX.Element {
   return (
     <Card.Root boxShadow="sm">
       <Card.Body p={4}>
         <Stack gap={3}>
-          <Text fontSize="sm" fontWeight="semibold" color="fg.muted" letterSpacing="wide">
-            {title.toUpperCase()}
-          </Text>
+          <HStack gap={2}>
+            {IconComponent && (
+              <Box color="fg.muted" fontSize="sm">
+                <IconComponent />
+              </Box>
+            )}
+            <Text fontSize="sm" fontWeight="semibold" color="fg.muted" letterSpacing="wide">
+              {title.toUpperCase()}
+            </Text>
+          </HStack>
           {children}
         </Stack>
       </Card.Body>
@@ -130,7 +158,7 @@ function StatBlock({
 
 function FcDataTotalsSection({ totals }: { totals: FcDataTotals }): React.JSX.Element {
   return (
-    <SectionCard title="Overview">
+    <SectionCard title="Overview" icon={FaClipboardList}>
       <SimpleGrid columns={{ base: 2, md: 4 }} gap={4}>
         <StatBlock label="Rounds recorded" value={totals.roundsRecorded.toLocaleString()} />
         <StatBlock
@@ -209,6 +237,105 @@ function FcDataTotalsSection({ totals }: { totals: FcDataTotals }): React.JSX.El
   );
 }
 
+function FcDataMonthHighlightSection({
+  highlight,
+}: {
+  highlight: FcDataMonthHighlight;
+}): React.JSX.Element | null {
+  if (!highlight.best || !highlight.worst) {
+    return null;
+  }
+
+  return (
+    <SectionCard title="Best & Worst Month" icon={FaTrophy}>
+      <SimpleGrid columns={{ base: 1, md: 2 }} gap={3}>
+        <Box
+          borderRadius="md"
+          p={3}
+          bg="green.subtle"
+          borderWidth="1px"
+          borderColor="green.emphasized"
+        >
+          <Text fontSize="xs" color="fg.muted">
+            Best month
+          </Text>
+          <Text fontSize="xl" fontWeight="bold" color="green.fg">
+            {highlight.best.label}
+          </Text>
+          <Text fontSize="sm" color="fg.muted">
+            {formatUnits(highlight.best.totalUnitsWon)} units ·{' '}
+            {displayPercent(highlight.best.winRate)} win rate
+          </Text>
+        </Box>
+        <Box
+          borderRadius="md"
+          p={3}
+          bg="orange.subtle"
+          borderWidth="1px"
+          borderColor="orange.emphasized"
+        >
+          <Text fontSize="xs" color="fg.muted">
+            Worst month
+          </Text>
+          <Text fontSize="xl" fontWeight="bold" color="orange.fg">
+            {highlight.worst.label}
+          </Text>
+          <Text fontSize="sm" color="fg.muted">
+            {formatUnits(highlight.worst.totalUnitsWon)} units ·{' '}
+            {displayPercent(highlight.worst.winRate)} win rate
+          </Text>
+        </Box>
+      </SimpleGrid>
+    </SectionCard>
+  );
+}
+
+function FcDataYearlyTable({ years }: { years: FcDataYearStats[] }): React.JSX.Element | null {
+  if (years.length < 2) {
+    return null;
+  }
+
+  return (
+    <SectionCard title="Yearly Breakdown" icon={FaCalendar}>
+      <Table.Root size="sm" width="full">
+        <Table.Header>
+          <Table.Row>
+            <Table.ColumnHeader>Year</Table.ColumnHeader>
+            <Table.ColumnHeader textAlign="right">Rounds</Table.ColumnHeader>
+            <Table.ColumnHeader textAlign="right">Total Won</Table.ColumnHeader>
+            <Table.ColumnHeader textAlign="right">Avg/Round</Table.ColumnHeader>
+            <Table.ColumnHeader textAlign="right">Win Rate</Table.ColumnHeader>
+            <Table.ColumnHeader textAlign="right">ROI</Table.ColumnHeader>
+            <Table.ColumnHeader textAlign="right">Best Round</Table.ColumnHeader>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {years.map(year => (
+            <Table.Row key={year.yearKey}>
+              <Table.Cell fontWeight="medium">{year.label}</Table.Cell>
+              <Table.Cell textAlign="right">{year.roundsPlayed.toLocaleString()}</Table.Cell>
+              <Table.Cell textAlign="right">{formatUnits(year.totalUnitsWon)}</Table.Cell>
+              <Table.Cell textAlign="right">{year.averageUnitsPerRound.toFixed(1)}</Table.Cell>
+              <Table.Cell textAlign="right">{displayPercent(year.winRate)}</Table.Cell>
+              <Table.Cell textAlign="right" color={roiColor(year.roi)} fontWeight="medium">
+                {formatRoi(year.roi)}
+              </Table.Cell>
+              <Table.Cell textAlign="right">
+                {year.bestRound && (
+                  <Link href={year.bestRound.url} target="_blank" fontSize="sm">
+                    #{year.bestRound.round} ({formatUnits(year.bestRound.unitsWon)}){' '}
+                    <LuExternalLink />
+                  </Link>
+                )}
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table.Root>
+    </SectionCard>
+  );
+}
+
 const RETURN_BUCKET_ORDER: FcDataReturnBucket[] = ['bust', 'partial', 'profit', 'double'];
 
 const RETURN_BUCKET_LABELS: Record<FcDataReturnBucket, string> = {
@@ -235,7 +362,7 @@ function FcDataReturnDistributionSection({
   }
 
   return (
-    <SectionCard title="Return Distribution">
+    <SectionCard title="Return Distribution" icon={FaChartPie}>
       <Box h="20px" borderRadius="md" overflow="hidden" display="flex">
         {RETURN_BUCKET_ORDER.filter(bucket => distribution[bucket] > 0).map(bucket => (
           <Box
@@ -261,7 +388,7 @@ function FcDataReturnDistributionSection({
 
 function FcDataMonthlyTable({ months }: { months: FcDataMonthStats[] }): React.JSX.Element {
   return (
-    <SectionCard title="Per-Month Breakdown">
+    <SectionCard title="Per-Month Breakdown" icon={FaCalendarDays}>
       <Box maxH="280px" overflowY="auto">
         <Table.Root size="sm" width="full">
           <Table.Header>
@@ -326,7 +453,7 @@ function FcDataMissedRoundsSection({
   }
 
   return (
-    <SectionCard title="Missed Rounds">
+    <SectionCard title="Missed Rounds" icon={FaTriangleExclamation}>
       <Text fontSize="sm" color="fg.muted">
         {gaps.length} gap{gaps.length === 1 ? '' : 's'} where one or more rounds weren&apos;t
         recorded
@@ -432,7 +559,7 @@ function FcDataAdvancedStatsSection({
   const maxArenaRate = Math.max(...stats.arenaUsage.map(a => a.lineParticipationRate), 0.01);
 
   return (
-    <SectionCard title="Advanced Stats (from round history)">
+    <SectionCard title="Advanced Stats (from round history)" icon={FaMagnifyingGlassChart}>
       <Text fontSize="xs" color="fg.muted">
         Decoded from {stats.fingerprint.matchedRounds.toLocaleString()} round
         {stats.fingerprint.matchedRounds === 1 ? '' : 's'} matched against the round history feed
@@ -511,7 +638,7 @@ function FcDataBetShapesSection({
   }
 
   return (
-    <SectionCard title="Bet Shapes">
+    <SectionCard title="Bet Shapes" icon={FaShapes}>
       <FcDataBetShapesChart shapes={shapes} />
       <Text fontSize="xs" color="fg.muted" fontStyle="italic">
         Gambit-shaped: every line is a subset of one fixed 5-pirate combo. Bustproof-shaped: some
@@ -627,11 +754,23 @@ export function FcDataModal({ isOpen, onClose }: FcDataModalProps): React.JSX.El
 
   const totals = React.useMemo(() => computeTotals(rows), [rows]);
   const months = React.useMemo(() => computeMonthlyStats(rows), [rows]);
+  const years = React.useMemo(() => computeYearlyStats(rows), [rows]);
+  const monthHighlight = React.useMemo(() => findBestAndWorstMonth(months), [months]);
   const cumulativeSeries = React.useMemo(() => computeCumulativeSeries(rows), [rows]);
   const roiSeries = React.useMemo(() => computeRoiSeries(rows), [rows]);
+  const rollingRoiSeries = React.useMemo(() => computeRollingRoiSeries(rows), [rows]);
   const returnDistribution = React.useMemo(() => computeReturnDistribution(rows), [rows]);
   const betShapeCounts = React.useMemo(() => computeBetShapeCounts(rows), [rows]);
   const rowsByRound = React.useMemo(() => new Map(rows.map(row => [row.round, row])), [rows]);
+
+  const shareSummary = React.useMemo(() => buildShareSummary(totals), [totals]);
+  const { copy: copySummary } = useClipboard({ value: shareSummary });
+  const [summaryCopied, setSummaryCopied] = React.useState(false);
+  const handleCopySummary = React.useCallback((): void => {
+    copySummary();
+    setSummaryCopied(true);
+    setTimeout(() => setSummaryCopied(false), 1500);
+  }, [copySummary]);
 
   const [advancedStatsRequested, setAdvancedStatsRequested] = React.useState(false);
   const feed = useBacktestPreviousRounds({ enabled: advancedStatsRequested });
@@ -730,9 +869,20 @@ export function FcDataModal({ isOpen, onClose }: FcDataModalProps): React.JSX.El
                           : ''}
                         .
                       </Text>
-                      <Button size="xs" variant="outline" onClick={handleLoadAnother}>
-                        Load another file
-                      </Button>
+                      <HStack gap={2}>
+                        <Button
+                          size="xs"
+                          variant="outline"
+                          colorPalette={summaryCopied ? 'nfc-green' : undefined}
+                          onClick={handleCopySummary}
+                        >
+                          {summaryCopied ? <FaCheck /> : <FaCopy />}
+                          {summaryCopied ? 'Copied!' : 'Copy Summary'}
+                        </Button>
+                        <Button size="xs" variant="outline" onClick={handleLoadAnother}>
+                          Load another file
+                        </Button>
+                      </HStack>
                     </HStack>
 
                     {!advancedStatsRequested && (
@@ -779,16 +929,24 @@ export function FcDataModal({ isOpen, onClose }: FcDataModalProps): React.JSX.El
 
                     <FcDataTotalsSection totals={totals} />
 
+                    <FcDataMonthHighlightSection highlight={monthHighlight} />
+
                     <FcDataReturnDistributionSection distribution={returnDistribution} />
 
                     <FcDataBetShapesSection shapes={betShapeCounts} />
 
                     <SimpleGrid columns={{ base: 1, md: 2 }} gap={3}>
                       <FcDataCumulativeChart series={cumulativeSeries} />
-                      <FcDataRoiChart series={roiSeries} />
+                      <FcDataRoiChart
+                        series={roiSeries}
+                        rollingSeries={rollingRoiSeries}
+                        rollingLabel={`${ROLLING_ROI_WINDOW}-round avg`}
+                      />
                     </SimpleGrid>
 
                     <FcDataMonthlyBarChart months={months} />
+
+                    <FcDataYearlyTable years={years} />
 
                     <FcDataMonthlyTable months={months} />
 

--- a/src/app/components/modals/FcDataModal.tsx
+++ b/src/app/components/modals/FcDataModal.tsx
@@ -20,12 +20,14 @@ import { LuExternalLink } from 'react-icons/lu';
 
 import { computeAdvancedStats, type FcDataAdvancedStats } from '../../analysis/fcDataAdvancedStats';
 import {
+  computeBetShapeCounts,
   computeCumulativeSeries,
   computeMonthlyStats,
   computeReturnDistribution,
   computeRoiSeries,
   computeTotals,
   findMissedRoundGaps,
+  type FcDataBetShapeCounts,
   type FcDataMissedRoundGap,
   type FcDataMonthStats,
   type FcDataReturnBucket,
@@ -361,7 +363,6 @@ function FcDataWarningsSection({
 }
 
 const EXPOSURE_BAR_COLOR = '#3182ce';
-const MAX_EXPOSURE_ROWS = 10;
 
 function PirateExposureBar({
   name,
@@ -396,10 +397,9 @@ function FcDataAdvancedStatsSection({
     return null;
   }
 
-  const topPirates = stats.pirateExposure.slice(0, MAX_EXPOSURE_ROWS);
-  const maxRate = Math.max(...topPirates.map(p => p.roundParticipationRate), 0.01);
+  const allPirates = stats.pirateExposure;
+  const maxRate = Math.max(...allPirates.map(p => p.roundParticipationRate), 0.01);
   const maxArenaRate = Math.max(...stats.arenaUsage.map(a => a.lineParticipationRate), 0.01);
-  const shapeTotal = stats.betShapes.total;
 
   return (
     <SectionCard title="Advanced Stats (from round history)">
@@ -432,13 +432,13 @@ function FcDataAdvancedStatsSection({
         />
       </SimpleGrid>
 
-      {topPirates.length > 0 && (
+      {allPirates.length > 0 && (
         <Stack gap={2}>
           <Text fontSize="sm" fontWeight="medium">
             Most bet pirates:
           </Text>
           <Stack gap={1}>
-            {topPirates.map(pirate => (
+            {allPirates.map(pirate => (
               <PirateExposureBar
                 key={pirate.pirateId}
                 name={pirate.name}
@@ -471,24 +471,39 @@ function FcDataAdvancedStatsSection({
           ))}
         </Stack>
       </Stack>
+    </SectionCard>
+  );
+}
 
-      {shapeTotal > 0 && (
-        <Stack gap={2}>
-          <Text fontSize="sm" fontWeight="medium">
-            Bet shapes:
-          </Text>
-          <Text fontSize="sm" color="fg.muted">
-            Gambit-shaped {displayPercent(stats.betShapes.gambitShaped / shapeTotal)} ·
-            Tenbet-shaped {displayPercent(stats.betShapes.tenbetShaped / shapeTotal)} · Other{' '}
-            {displayPercent(stats.betShapes.other / shapeTotal)}
-          </Text>
-          <Text fontSize="xs" color="fg.muted" fontStyle="italic">
-            Gambit-shaped: every line is a subset of one fixed 5-pirate combo. Tenbet-shaped: one
-            pirate is held fixed across every line while the rest vary. Structural guesses only -
-            not based on which NeoBot command generated the bet.
-          </Text>
-        </Stack>
-      )}
+const BET_SHAPE_LABELS: { key: keyof FcDataBetShapeCounts; label: string }[] = [
+  { key: 'gambitShaped', label: 'Gambit-shaped' },
+  { key: 'bustproofShaped', label: 'Bustproof-shaped' },
+  { key: 'crazyShaped', label: 'Crazy-shaped' },
+  { key: 'tenbetShaped', label: 'Tenbet-shaped' },
+  { key: 'other', label: 'Other' },
+];
+
+function FcDataBetShapesSection({
+  shapes,
+}: {
+  shapes: FcDataBetShapeCounts;
+}): React.JSX.Element | null {
+  if (shapes.total === 0) {
+    return null;
+  }
+
+  return (
+    <SectionCard title="Bet Shapes">
+      <Text fontSize="sm" color="fg.muted">
+        {BET_SHAPE_LABELS.map(
+          ({ key, label }) => `${label} ${displayPercent(shapes[key] / shapes.total)}`,
+        ).join(' · ')}
+      </Text>
+      <Text fontSize="xs" color="fg.muted" fontStyle="italic">
+        Gambit-shaped: every line is a subset of one fixed 5-pirate combo. Bustproof-shaped: some
+        arena has all 4 of its pirates covered. Crazy-shaped: every line picks a pirate in all 5
+        arenas. Tenbet-shaped: one pirate is held fixed across every line while the rest vary.
+      </Text>
     </SectionCard>
   );
 }
@@ -601,6 +616,7 @@ export function FcDataModal({ isOpen, onClose }: FcDataModalProps): React.JSX.El
   const cumulativeSeries = React.useMemo(() => computeCumulativeSeries(rows), [rows]);
   const roiSeries = React.useMemo(() => computeRoiSeries(rows), [rows]);
   const returnDistribution = React.useMemo(() => computeReturnDistribution(rows), [rows]);
+  const betShapeCounts = React.useMemo(() => computeBetShapeCounts(rows), [rows]);
   const missedRoundGaps = React.useMemo(() => findMissedRoundGaps(rows), [rows]);
   const rowsByRound = React.useMemo(() => new Map(rows.map(row => [row.round, row])), [rows]);
 
@@ -735,6 +751,8 @@ export function FcDataModal({ isOpen, onClose }: FcDataModalProps): React.JSX.El
                     <FcDataTotalsSection totals={totals} />
 
                     <FcDataReturnDistributionSection distribution={returnDistribution} />
+
+                    <FcDataBetShapesSection shapes={betShapeCounts} />
 
                     <SimpleGrid columns={{ base: 1, md: 2 }} gap={3}>
                       <FcDataCumulativeChart series={cumulativeSeries} />

--- a/src/app/components/modals/FcDataModal.tsx
+++ b/src/app/components/modals/FcDataModal.tsx
@@ -170,7 +170,11 @@ function FcDataTotalsSection({ totals }: { totals: FcDataTotals }): React.JSX.El
           label="Current streak"
           value={
             totals.currentStreak
-              ? `${totals.currentStreak.count.toLocaleString()} ${totals.currentStreak.type === 'win' ? 'win' : 'bust'}${totals.currentStreak.count === 1 ? '' : 's'}`
+              ? `${totals.currentStreak.count.toLocaleString()} ${totals.currentStreak.type === 'win' ? 'win' : 'bust'}${totals.currentStreak.count === 1 ? '' : 's'}${
+                  totals.currentStreak.type === 'win'
+                    ? ` (${formatUnits(totals.currentStreak.totalUnitsWon)} units)`
+                    : ''
+                }`
               : '-'
           }
           sub={

--- a/src/app/components/modals/FcDataModal.tsx
+++ b/src/app/components/modals/FcDataModal.tsx
@@ -20,6 +20,7 @@ import { FaFileCsv } from 'react-icons/fa';
 import {
   computeCumulativeSeries,
   computeMonthlyStats,
+  computeRoiSeries,
   computeTotals,
   findMissedRoundGaps,
   type FcDataMissedRoundGap,
@@ -29,6 +30,7 @@ import {
 import { parseFcDataCsv, type FcDataParseResult, type FcDataRow } from '../../data/fcDataCsv';
 import { FcDataCumulativeChart } from '../charts/FcDataCumulativeChart';
 import { FcDataMonthlyBarChart } from '../charts/FcDataMonthlyBarChart';
+import { FcDataRoiChart } from '../charts/FcDataRoiChart';
 
 interface FcDataModalProps {
   isOpen: boolean;
@@ -406,6 +408,7 @@ export function FcDataModal({ isOpen, onClose }: FcDataModalProps): React.JSX.El
   const totals = React.useMemo(() => computeTotals(rows), [rows]);
   const months = React.useMemo(() => computeMonthlyStats(rows), [rows]);
   const cumulativeSeries = React.useMemo(() => computeCumulativeSeries(rows), [rows]);
+  const roiSeries = React.useMemo(() => computeRoiSeries(rows), [rows]);
   const missedRoundGaps = React.useMemo(() => findMissedRoundGaps(rows), [rows]);
   const rowsByRound = React.useMemo(() => new Map(rows.map(row => [row.round, row])), [rows]);
 
@@ -481,8 +484,10 @@ export function FcDataModal({ isOpen, onClose }: FcDataModalProps): React.JSX.El
 
                     <SimpleGrid columns={{ base: 1, md: 2 }} gap={3}>
                       <FcDataCumulativeChart series={cumulativeSeries} />
-                      <FcDataMonthlyBarChart months={months} />
+                      <FcDataRoiChart series={roiSeries} />
                     </SimpleGrid>
+
+                    <FcDataMonthlyBarChart months={months} />
 
                     <FcDataMonthlyTable months={months} />
 

--- a/src/app/components/modals/FcDataModal.tsx
+++ b/src/app/components/modals/FcDataModal.tsx
@@ -16,6 +16,7 @@ import {
 import { format } from 'date-fns';
 import * as React from 'react';
 import { FaChartBar, FaFileCsv } from 'react-icons/fa';
+import { LuExternalLink } from 'react-icons/lu';
 
 import { computeAdvancedStats, type FcDataAdvancedStats } from '../../analysis/fcDataAdvancedStats';
 import {
@@ -163,7 +164,8 @@ function FcDataTotalsSection({ totals }: { totals: FcDataTotals }): React.JSX.El
           value={
             totals.bestRound ? (
               <Link href={totals.bestRound.url} target="_blank" fontSize="lg">
-                #{totals.bestRound.round} ({formatUnits(totals.bestRound.unitsWon)})
+                #{totals.bestRound.round} ({formatUnits(totals.bestRound.unitsWon)}){' '}
+                <LuExternalLink />
               </Link>
             ) : (
               '-'
@@ -267,7 +269,8 @@ function FcDataMonthlyTable({ months }: { months: FcDataMonthStats[] }): React.J
                 <Table.Cell textAlign="right">
                   {month.bestRound && (
                     <Link href={month.bestRound.url} target="_blank" fontSize="sm">
-                      #{month.bestRound.round} ({formatUnits(month.bestRound.unitsWon)})
+                      #{month.bestRound.round} ({formatUnits(month.bestRound.unitsWon)}){' '}
+                      <LuExternalLink />
                     </Link>
                   )}
                 </Table.Cell>
@@ -311,7 +314,7 @@ function FcDataMissedRoundsSection({
               {gap.missingCount} round{gap.missingCount === 1 ? '' : 's'} missed between{' '}
               {afterUrl ? (
                 <Link href={afterUrl} target="_blank" fontSize="sm">
-                  #{gap.afterRound}
+                  #{gap.afterRound} <LuExternalLink />
                 </Link>
               ) : (
                 `#${gap.afterRound}`
@@ -319,7 +322,7 @@ function FcDataMissedRoundsSection({
               and{' '}
               {beforeUrl ? (
                 <Link href={beforeUrl} target="_blank" fontSize="sm">
-                  #{gap.beforeRound}
+                  #{gap.beforeRound} <LuExternalLink />
                 </Link>
               ) : (
                 `#${gap.beforeRound}`

--- a/src/app/components/modals/FcDataModal.tsx
+++ b/src/app/components/modals/FcDataModal.tsx
@@ -379,7 +379,7 @@ export function FcDataModal({ isOpen, onClose }: FcDataModalProps): React.JSX.El
         <Dialog.Positioner>
           <Dialog.Content>
             <Dialog.Header>
-              <Dialog.Title>FC Data Import</Dialog.Title>
+              <Dialog.Title>FC Data Visualizer</Dialog.Title>
               <Dialog.CloseTrigger asChild>
                 <CloseButton size="sm" />
               </Dialog.CloseTrigger>

--- a/src/app/components/modals/FcDataModal.tsx
+++ b/src/app/components/modals/FcDataModal.tsx
@@ -460,10 +460,7 @@ function FcDataAdvancedStatsSection({
             ))}
           </Stack>
           <Text fontSize="xs" color="fg.muted" fontStyle="italic">
-            Share of matched rounds where the pirate appeared in at least one active bet line.
-            &quot;Net when included&quot; isn&apos;t shown per-pirate since a round&apos;s total
-            units won can&apos;t be split between co-occurring pirates without knowing which line
-            actually won.
+            Percent of rounds where you had that pirate in at least one bet line.
           </Text>
         </Stack>
       )}

--- a/src/app/data/__tests__/fcDataCsv.test.ts
+++ b/src/app/data/__tests__/fcDataCsv.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseFcDataCsv, parseFcDate } from '../fcDataCsv';
+
+describe('parseFcDate', () => {
+  it('parses a valid DD/MM/YY date', () => {
+    const date = parseFcDate('24/04/18');
+    expect(date).not.toBeNull();
+    expect(date?.getFullYear()).toBe(2018);
+    expect(date?.getMonth()).toBe(3);
+    expect(date?.getDate()).toBe(24);
+  });
+
+  it('pivots the two-digit year at the boundary', () => {
+    expect(parseFcDate('01/01/69')?.getFullYear()).toBe(2069);
+    expect(parseFcDate('01/01/70')?.getFullYear()).toBe(1970);
+  });
+
+  it('accepts a valid leap day', () => {
+    const date = parseFcDate('29/02/24');
+    expect(date).not.toBeNull();
+    expect(date?.getMonth()).toBe(1);
+    expect(date?.getDate()).toBe(29);
+  });
+
+  it('rejects a leap day in a non-leap year instead of rolling over', () => {
+    expect(parseFcDate('29/02/23')).toBeNull();
+  });
+
+  it('rejects out-of-range months and days', () => {
+    expect(parseFcDate('13/13/24')).toBeNull();
+    expect(parseFcDate('32/01/24')).toBeNull();
+  });
+
+  it('rejects garbage input', () => {
+    expect(parseFcDate('not-a-date')).toBeNull();
+    expect(parseFcDate('')).toBeNull();
+    expect(parseFcDate('2024-01-01')).toBeNull();
+  });
+});
+
+describe('parseFcDataCsv', () => {
+  const header = 'Date, Round, Units Won, NeoFoodClub URL';
+  const row1 = '24/04/18, 6927, 0, https://neofood.club/#round=6927&b=uyeewuweemueeawkycewuyjey';
+  const row2 = '25/04/18, 6928, 8, https://neofood.club/#round=6928&b=rudodpudokradofpusekwudkd';
+  const row3 = '26/04/18, 6929, 12, https://neofood.club/#round=6929&b=ksccpktccukshdaksmdvkkcnp';
+
+  it('parses a valid multi-row file with the header, trimming leading spaces', () => {
+    const { rows, warnings } = parseFcDataCsv([header, row1, row2, row3].join('\n'));
+
+    expect(warnings).toHaveLength(0);
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toEqual({
+      date: new Date(2018, 3, 24),
+      rawDate: '24/04/18',
+      round: 6927,
+      unitsWon: 0,
+      url: 'https://neofood.club/#round=6927&b=uyeewuweemueeawkycewuyjey',
+    });
+    expect(rows[1]!.round).toBe(6928);
+    expect(rows[1]!.unitsWon).toBe(8);
+    expect(rows[2]!.round).toBe(6929);
+  });
+
+  it('parses a file with no header, keeping the first data row', () => {
+    const { rows, warnings } = parseFcDataCsv([row1, row2].join('\n'));
+
+    expect(warnings).toHaveLength(0);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!.round).toBe(6927);
+  });
+
+  it('ignores blank leading, trailing, and interior lines', () => {
+    const { rows, warnings } = parseFcDataCsv(['', header, row1, '', row2, '', ''].join('\n'));
+
+    expect(warnings).toHaveLength(0);
+    expect(rows).toHaveLength(2);
+  });
+
+  it('handles CRLF line endings', () => {
+    const { rows, warnings } = parseFcDataCsv([header, row1, row2].join('\r\n'));
+
+    expect(warnings).toHaveLength(0);
+    expect(rows).toHaveLength(2);
+  });
+
+  it('sorts rows ascending by round even if the input is out of order', () => {
+    const { rows } = parseFcDataCsv([header, row3, row1, row2].join('\n'));
+
+    expect(rows.map(r => r.round)).toEqual([6927, 6928, 6929]);
+  });
+
+  it('warns on and skips a row with the wrong field count, keeping other rows', () => {
+    const { rows, warnings } = parseFcDataCsv([header, row1, '24/04/18, 6930, 0', row2].join('\n'));
+
+    expect(rows).toHaveLength(2);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.line).toBe(3);
+    expect(warnings[0]!.reason).toMatch(/4 fields/);
+  });
+
+  it('warns on and skips a row with a non-numeric round', () => {
+    const { rows, warnings } = parseFcDataCsv(
+      [header, row1, '24/04/18, abc, 0, https://neofood.club/#round=1', row2].join('\n'),
+    );
+
+    expect(rows).toHaveLength(2);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.reason).toMatch(/invalid round/);
+  });
+
+  it('warns on and skips a row with an invalid units won value', () => {
+    const { rows, warnings } = parseFcDataCsv(
+      [header, row1, '24/04/18, 6930, -5, https://neofood.club/#round=6930', row2].join('\n'),
+    );
+
+    expect(rows).toHaveLength(2);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.reason).toMatch(/invalid units won/);
+  });
+
+  it('warns on and skips a row with an unparseable date', () => {
+    const { rows, warnings } = parseFcDataCsv(
+      [header, row1, 'not-a-date, 6930, 0, https://neofood.club/#round=6930', row2].join('\n'),
+    );
+
+    expect(rows).toHaveLength(2);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.reason).toMatch(/unparseable date/);
+  });
+
+  it('warns on and skips a row with a missing or invalid URL', () => {
+    const { rows, warnings } = parseFcDataCsv(
+      [header, row1, '24/04/18, 6930, 0, not-a-url', row2].join('\n'),
+    );
+
+    expect(rows).toHaveLength(2);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.reason).toMatch(/URL/);
+  });
+
+  it('returns an empty result for empty input', () => {
+    expect(parseFcDataCsv('')).toEqual({ rows: [], warnings: [] });
+    expect(parseFcDataCsv('   \n  \n')).toEqual({ rows: [], warnings: [] });
+  });
+});

--- a/src/app/data/fcDataCsv.ts
+++ b/src/app/data/fcDataCsv.ts
@@ -1,0 +1,127 @@
+/** One parsed data row from fc_data.csv (a NeoBot personal bet-history export). */
+export interface FcDataRow {
+  /** Local midnight, parsed from DD/MM/YY. */
+  date: Date;
+  /** Original DD/MM/YY string as it appeared in the CSV, for display/debugging. */
+  rawDate: string;
+  round: number;
+  unitsWon: number;
+  /** The exact bet URL from the CSV row - used directly, never reconstructed. */
+  url: string;
+}
+
+export interface FcDataParseWarning {
+  line: number;
+  raw: string;
+  reason: string;
+}
+
+export interface FcDataParseResult {
+  /** Sorted ascending by round. */
+  rows: FcDataRow[];
+  warnings: FcDataParseWarning[];
+}
+
+const HEADER_PATTERN = /^date\s*,\s*round\s*,\s*units\s*won\s*,\s*neofoodclub\s*url\s*$/i;
+const DATE_PATTERN = /^(\d{1,2})\/(\d{1,2})\/(\d{2})$/;
+const TWO_DIGIT_YEAR_PIVOT = 70;
+
+/**
+ * Parses a DD/MM/YY date string, pivoting the 2-digit year at 70
+ * (69 -> 2069, 70 -> 1970) and rejecting calendar-invalid dates (e.g.
+ * 31/02/24) instead of letting them silently roll over to the next month.
+ */
+export function parseFcDate(raw: string): Date | null {
+  const match = DATE_PATTERN.exec(raw.trim());
+  if (!match) {
+    return null;
+  }
+
+  const day = Number(match[1]);
+  const month = Number(match[2]);
+  const twoDigitYear = Number(match[3]);
+
+  if (month < 1 || month > 12 || day < 1 || day > 31) {
+    return null;
+  }
+
+  const year = twoDigitYear < TWO_DIGIT_YEAR_PIVOT ? 2000 + twoDigitYear : 1900 + twoDigitYear;
+  const date = new Date(year, month - 1, day);
+
+  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+    return null;
+  }
+
+  return date;
+}
+
+/**
+ * Parses a NeoBot fc_data.csv export into rows, skipping and warning on any
+ * malformed line rather than failing the whole import.
+ */
+export function parseFcDataCsv(text: string): FcDataParseResult {
+  const rows: FcDataRow[] = [];
+  const warnings: FcDataParseWarning[] = [];
+
+  const lines = text.split(/\r?\n/);
+  let sawFirstNonBlankLine = false;
+
+  lines.forEach((rawLine, index) => {
+    const lineNumber = index + 1;
+    const line = rawLine.trim();
+    if (line.length === 0) {
+      return;
+    }
+
+    const isFirstNonBlankLine = !sawFirstNonBlankLine;
+    sawFirstNonBlankLine = true;
+
+    if (isFirstNonBlankLine && HEADER_PATTERN.test(line)) {
+      return;
+    }
+
+    const fields = line.split(',').map(field => field.trim());
+    if (fields.length !== 4) {
+      warnings.push({
+        line: lineNumber,
+        raw: rawLine,
+        reason: `expected 4 fields, got ${fields.length}`,
+      });
+      return;
+    }
+
+    const rawDate = fields[0]!;
+    const roundStr = fields[1]!;
+    const unitsStr = fields[2]!;
+    const url = fields[3]!;
+
+    const date = parseFcDate(rawDate);
+    if (date === null) {
+      warnings.push({ line: lineNumber, raw: rawLine, reason: `unparseable date "${rawDate}"` });
+      return;
+    }
+
+    const round = Number.parseInt(roundStr, 10);
+    if (!Number.isFinite(round) || round <= 0) {
+      warnings.push({ line: lineNumber, raw: rawLine, reason: `invalid round "${roundStr}"` });
+      return;
+    }
+
+    const unitsWon = Number.parseInt(unitsStr, 10);
+    if (!Number.isFinite(unitsWon) || unitsWon < 0) {
+      warnings.push({ line: lineNumber, raw: rawLine, reason: `invalid units won "${unitsStr}"` });
+      return;
+    }
+
+    if (!url || !url.startsWith('http')) {
+      warnings.push({ line: lineNumber, raw: rawLine, reason: 'missing or invalid URL' });
+      return;
+    }
+
+    rows.push({ date, rawDate, round, unitsWon, url });
+  });
+
+  rows.sort((a, b) => a.round - b.round);
+
+  return { rows, warnings };
+}


### PR DESCRIPTION
## Summary
- New dev-mode tool that lets you drag-and-drop or browse-select a fc_data.csv export from NeoBot (r/Neopets Discord bot, `?fcdata` command) to see charts and stats about your personal NeoFoodClub betting history. Everything is processed locally in the browser - the file is never uploaded anywhere.
- Overview: total stats (rounds recorded, total units won, average per round, win rate, longest win/bust streaks with date ranges, current streak, best round, date range), plus a "Copy Summary" button for a Discord-friendly stats blurb.
- Best & Worst Month callout, once there are at least 2 months of history.
- Return distribution (Bust/Partial/Profit/Double+) and bet shapes (gambit/bustproof/crazy/tenbet/other, as a pie chart) - both classified purely from the decoded bet hash, no external data needed.
- Cumulative-winnings chart and a running-ROI chart with a 30-round rolling-average overlay and breakeven line, a monthly-totals bar chart, a yearly breakdown table (2+ years of history), and the per-month table (rounds, total won, win rate, ROI, running ROI, best round).
- Missed-round detection, validated against the round-history feed once loaded so maintenance-period round gaps aren't misreported as missed bets.
- Optional "Load Detailed Stats" panel: cross-references each round against the cached round-history feed (~13MB, same one Odds Anomalies/Pirate Matchups use) to decode actual pirate identities - all pirates by participation rate, arena usage, average pirates per line, average unique pirates per round, and favorite anchor pirate. Has a Refresh button that skips recomputation when the feed hasn't changed. TER/bust-probability/max-payout are a deferred follow-up since they need the app's probability/payout engine, not just round+bet identity.
- CSV parsing and stats computation are pure functions with unit tests: src/app/data/fcDataCsv.ts, src/app/analysis/fcDataStats.ts, src/app/analysis/fcDataAdvancedStats.ts.

Stacked on top: #1014 lifts the missing-round-data detection into the Round End-Time Drift chart.