### PR TITLE
Highlight missing round data in the Round End-Time Drift chart

### DIFF
--- a/src/app/analysis/fcDataStats.ts
+++ b/src/app/analysis/fcDataStats.ts
@@ -2,6 +2,7 @@ import { format } from 'date-fns';
 
 import type { FcDataRow } from '../data/fcDataCsv';
 import { parseBetUrl } from '../util';
+import { findRoundGaps, type RoundGap } from '../util/roundGaps';
 
 export interface FcDataWinStreak {
   count: number;
@@ -89,11 +90,7 @@ export interface FcDataRoiPoint {
   roi: number;
 }
 
-export interface FcDataMissedRoundGap {
-  afterRound: number;
-  beforeRound: number;
-  missingCount: number;
-}
+export type FcDataMissedRoundGap = RoundGap;
 
 export type FcDataReturnBucket = 'bust' | 'partial' | 'profit' | 'double';
 
@@ -535,18 +532,7 @@ export function computeRollingRoiSeries(
 }
 
 export function findMissedRoundGaps(rows: FcDataRow[]): FcDataMissedRoundGap[] {
-  const gaps: FcDataMissedRoundGap[] = [];
-
-  for (let i = 1; i < rows.length; i++) {
-    const afterRound = rows[i - 1]!.round;
-    const beforeRound = rows[i]!.round;
-    const missingCount = beforeRound - afterRound - 1;
-    if (missingCount > 0) {
-      gaps.push({ afterRound, beforeRound, missingCount });
-    }
-  }
-
-  return gaps;
+  return findRoundGaps(rows.map(row => row.round));
 }
 
 /** A short, Discord-friendly plain-text stats blurb, ready to paste back into the server the CSV came from. */

--- a/src/app/components/charts/RoundEndDriftChart.tsx
+++ b/src/app/components/charts/RoundEndDriftChart.tsx
@@ -16,6 +16,7 @@ import { downsampleForChart } from '../../backtest/runBacktest';
 import {
   SCRAPER_LAG_TOLERANCE_MINUTES,
   classifyDrift,
+  type DriftDataGap,
   type DriftPoint,
   type DriftStatus,
 } from '../../devTiming/drift';
@@ -27,6 +28,8 @@ ChartJS.register(LinearScale, PointElement, LineElement, Tooltip, Legend, annota
 const LINE_COLOR = '#3182ce';
 const LATE_DRIFT_FILL = 'rgba(221, 107, 32, 0.08)';
 const SCRAPER_LAG_FILL = 'rgba(49, 130, 206, 0.10)';
+const MISSING_DATA_FILL = 'rgba(236, 201, 75, 0.25)';
+const MISSING_DATA_BORDER = 'rgba(214, 158, 46, 0.6)';
 
 function formatOffset(value: number): string {
   if (value === 0) {
@@ -49,9 +52,13 @@ function statusLabel(status: DriftStatus): string {
 
 interface RoundEndDriftChartProps {
   points: DriftPoint[];
+  gaps?: DriftDataGap[];
 }
 
-export function RoundEndDriftChart({ points }: RoundEndDriftChartProps): React.JSX.Element {
+export function RoundEndDriftChart({
+  points,
+  gaps = [],
+}: RoundEndDriftChartProps): React.JSX.Element {
   const { colorMode } = useColorMode();
   const isDarkLikeMode = colorMode !== 'light';
 
@@ -79,6 +86,34 @@ export function RoundEndDriftChart({ points }: RoundEndDriftChartProps): React.J
 
   const gridColor = isDarkLikeMode ? '#6272a4' : undefined;
   const textColor = isDarkLikeMode ? '#ffffff' : undefined;
+  const missingDataLabelColor = isDarkLikeMode ? '#f6e05e' : '#975a16';
+
+  const gapAnnotations = useMemo(
+    () =>
+      Object.fromEntries(
+        gaps.map((gap, index) => [
+          `missingDataGap${index}`,
+          {
+            type: 'box' as const,
+            xMin: gap.afterRound,
+            xMax: gap.beforeRound,
+            backgroundColor: MISSING_DATA_FILL,
+            borderColor: MISSING_DATA_BORDER,
+            borderWidth: 1,
+            borderDash: [4, 4],
+            label: {
+              display: true,
+              content: 'No data',
+              position: { x: 'center' as const, y: 'start' as const },
+              backgroundColor: 'transparent',
+              color: missingDataLabelColor,
+              font: { size: 10 },
+            },
+          },
+        ]),
+      ),
+    [gaps, missingDataLabelColor],
+  );
 
   const options = useMemo(
     () => ({
@@ -93,6 +128,7 @@ export function RoundEndDriftChart({ points }: RoundEndDriftChartProps): React.J
         },
         annotation: {
           annotations: {
+            ...gapAnnotations,
             onTimeLine: {
               type: 'line' as const,
               yMin: 0,
@@ -166,7 +202,7 @@ export function RoundEndDriftChart({ points }: RoundEndDriftChartProps): React.J
         },
       },
     }),
-    [gridColor, textColor, isDarkLikeMode],
+    [gridColor, textColor, isDarkLikeMode, gapAnnotations],
   );
 
   return (

--- a/src/app/components/modals/RoundEndDriftModal.tsx
+++ b/src/app/components/modals/RoundEndDriftModal.tsx
@@ -11,7 +11,12 @@ import {
 } from '@chakra-ui/react';
 import * as React from 'react';
 
-import { computeDrift, summarizeDrift, type DriftPoint } from '../../devTiming/drift';
+import {
+  computeDrift,
+  findDriftDataGaps,
+  summarizeDrift,
+  type DriftPoint,
+} from '../../devTiming/drift';
 import { useRoundTiming } from '../../devTiming/useRoundTiming';
 import { RoundEndDriftChart } from '../charts/RoundEndDriftChart';
 
@@ -82,6 +87,7 @@ export function RoundEndDriftModal({
   }, [allPoints, rangePreset, minRoundInput, maxRoundInput]);
 
   const summary = React.useMemo(() => summarizeDrift(visiblePoints), [visiblePoints]);
+  const dataGaps = React.useMemo(() => findDriftDataGaps(visiblePoints), [visiblePoints]);
 
   const statusText = React.useMemo(() => {
     if (timing.status === 'loading') {
@@ -126,7 +132,9 @@ export function RoundEndDriftModal({
                 <Text fontSize="sm" color="fg.muted">
                   Plots how far each round&apos;s actual end time (when winners post) drifted from
                   the expected 2:15 PM Pacific. The shaded band at the bottom is the 0&ndash;2
-                  minute window - ends in that range are just scraper lag, not drift.
+                  minute window - ends in that range are just scraper lag, not drift. Yellow bands
+                  mark round ranges with no end-time data at all in the feed (e.g. a NeoFoodClub
+                  outage), not just rounds excluded by the range filter below.
                 </Text>
 
                 <HStack justify="space-between" flexWrap="wrap" gap={2}>
@@ -203,9 +211,17 @@ export function RoundEndDriftModal({
                             : '\u2014'
                         }
                       />
+                      <SummaryStat
+                        label="Missing rounds"
+                        value={
+                          dataGaps.length > 0
+                            ? `${dataGaps.reduce((sum, gap) => sum + gap.missingCount, 0)} in ${dataGaps.length} gap${dataGaps.length === 1 ? '' : 's'}`
+                            : 'none'
+                        }
+                      />
                     </SimpleGrid>
 
-                    <RoundEndDriftChart points={visiblePoints} />
+                    <RoundEndDriftChart points={visiblePoints} gaps={dataGaps} />
                   </>
                 )}
 

--- a/src/app/devTiming/__tests__/drift.test.ts
+++ b/src/app/devTiming/__tests__/drift.test.ts
@@ -6,6 +6,7 @@ import {
   computeDrift,
   computeOffsetMinutes,
   expectedEndUtcFor,
+  findDriftDataGaps,
   summarizeDrift,
 } from '../drift';
 
@@ -112,5 +113,29 @@ describe('summarizeDrift', () => {
     const summary = summarizeDrift(points);
     expect(summary.mostDelayedRound).toBeNull();
     expect(summary.maxOffsetMinutes).toBeNull();
+  });
+});
+
+describe('findDriftDataGaps', () => {
+  it('detects a run of round numbers with no end-time data', () => {
+    const points = computeDrift([
+      { round: 1, timestamp: '2026-08-15T21:15:30Z' },
+      { round: 5, timestamp: '2026-08-19T21:15:30Z' },
+    ]);
+
+    expect(findDriftDataGaps(points)).toEqual([{ afterRound: 1, beforeRound: 5, missingCount: 3 }]);
+  });
+
+  it('returns no gaps for consecutive rounds', () => {
+    const points = computeDrift([
+      { round: 1, timestamp: '2026-08-15T21:15:30Z' },
+      { round: 2, timestamp: '2026-08-16T21:15:30Z' },
+    ]);
+
+    expect(findDriftDataGaps(points)).toEqual([]);
+  });
+
+  it('returns no gaps for empty input', () => {
+    expect(findDriftDataGaps([])).toEqual([]);
   });
 });

--- a/src/app/devTiming/drift.ts
+++ b/src/app/devTiming/drift.ts
@@ -1,5 +1,7 @@
 import { fromZonedTime, toZonedTime } from 'date-fns-tz';
 
+import { findRoundGaps, type RoundGap } from '../util/roundGaps';
+
 import type { RoundTiming } from './roundTiming';
 
 export const PACIFIC_TIMEZONE = 'America/Los_Angeles';
@@ -29,6 +31,9 @@ export interface DriftSummary {
   mostDelayedRound: number | null;
   maxOffsetMinutes: number | null;
 }
+
+/** A run of round numbers with no end-time data at all - e.g. a NeoFoodClub outage. */
+export type DriftDataGap = RoundGap;
 
 /**
  * Builds the expected end-of-round instant (2:15 PM Pacific, DST-aware) for
@@ -117,4 +122,15 @@ export function summarizeDrift(points: DriftPoint[]): DriftSummary {
     mostDelayedRound,
     maxOffsetMinutes,
   };
+}
+
+/**
+ * Finds round-number ranges within `points` that have no end-time data at
+ * all, assuming `points` is sorted ascending by round (as `computeDrift`
+ * produces). A gap here means the feed itself has nothing for those rounds -
+ * most commonly because NeoFoodClub didn't run them (a maintenance outage),
+ * not that this chart's round-range filter excluded them.
+ */
+export function findDriftDataGaps(points: DriftPoint[]): DriftDataGap[] {
+  return findRoundGaps(points.map(point => point.round));
 }

--- a/src/app/util/__tests__/roundGaps.test.ts
+++ b/src/app/util/__tests__/roundGaps.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { findRoundGaps } from '../roundGaps';
+
+describe('findRoundGaps', () => {
+  it('returns no gaps for consecutive round numbers', () => {
+    expect(findRoundGaps([1, 2, 3])).toEqual([]);
+  });
+
+  it('detects a single gap', () => {
+    expect(findRoundGaps([1, 5])).toEqual([{ afterRound: 1, beforeRound: 5, missingCount: 3 }]);
+  });
+
+  it('detects multiple gaps in order', () => {
+    expect(findRoundGaps([1, 3, 4, 10])).toEqual([
+      { afterRound: 1, beforeRound: 3, missingCount: 1 },
+      { afterRound: 4, beforeRound: 10, missingCount: 5 },
+    ]);
+  });
+
+  it('returns no gaps for a single-element or empty input', () => {
+    expect(findRoundGaps([1])).toEqual([]);
+    expect(findRoundGaps([])).toEqual([]);
+  });
+});

--- a/src/app/util/roundGaps.ts
+++ b/src/app/util/roundGaps.ts
@@ -1,0 +1,26 @@
+export interface RoundGap {
+  afterRound: number;
+  beforeRound: number;
+  missingCount: number;
+}
+
+/**
+ * Finds gaps in a sorted-ascending list of round numbers - runs of
+ * consecutive round numbers that never appear at all between two rounds that
+ * do. Only interior gaps are reported; nothing before the first or after the
+ * last round number counts as a gap.
+ */
+export function findRoundGaps(roundNumbers: number[]): RoundGap[] {
+  const gaps: RoundGap[] = [];
+
+  for (let i = 1; i < roundNumbers.length; i++) {
+    const afterRound = roundNumbers[i - 1]!;
+    const beforeRound = roundNumbers[i]!;
+    const missingCount = beforeRound - afterRound - 1;
+    if (missingCount > 0) {
+      gaps.push({ afterRound, beforeRound, missingCount });
+    }
+  }
+
+  return gaps;
+}


### PR DESCRIPTION
## Summary
Stacked on #1013 - lifts the round-number-gap detection built there for the FC Data Visualizer into a shared util and reuses it in the Round End-Time Drift modal.

- Extracted `findRoundGaps` into `src/app/util/roundGaps.ts`, a generic helper that finds runs of missing round numbers in a sorted list. `fcDataStats.ts`'s `findMissedRoundGaps` now delegates to it instead of duplicating the loop.
- Added `findDriftDataGaps` to `src/app/devTiming/drift.ts`, using the shared helper on the drift chart's round-timing data.
- `RoundEndDriftChart` now accepts an optional `gaps` prop and renders each gap as a yellow band (with a "No data" label) spanning the full chart height, so it's visually distinct from the existing scraper-lag band.
- `RoundEndDriftModal` computes gaps from the currently visible points, passes them to the chart, adds a "Missing rounds" summary stat, and clarifies in the intro text that these bands mean "no data in the feed at all" (e.g. a NeoFoodClub outage), not just rounds excluded by the round-range filter.