### PR TITLE
Add ROI to FC Data Visualizer overview and share summary

### DIFF
--- a/src/app/analysis/__tests__/fcDataStats.test.ts
+++ b/src/app/analysis/__tests__/fcDataStats.test.ts
@@ -43,6 +43,8 @@ describe('computeTotals', () => {
       totalUnitsWon: 0,
       averageUnitsPerRound: 0,
       winRate: 0,
+      totalActiveBetLines: 0,
+      roi: 0,
       bestRound: null,
       longestWinStreak: null,
       longestLossStreak: null,
@@ -50,6 +52,25 @@ describe('computeTotals', () => {
       firstRound: null,
       lastRound: null,
     });
+  });
+
+  it('computes all-time roi as totalUnitsWon / totalActiveBetLines', () => {
+    const rows = [
+      makeRow(1, 4, new Date(2024, 0, 1), makeBetUrl(1, [[1, 0, 0, 0, 0]])),
+      makeRow(
+        2,
+        0,
+        new Date(2024, 0, 2),
+        makeBetUrl(2, [
+          [1, 0, 0, 0, 0],
+          [0, 2, 0, 0, 0],
+        ]),
+      ),
+    ];
+    const totals = computeTotals(rows);
+
+    expect(totals.totalActiveBetLines).toBe(3);
+    expect(totals.roi).toBe(4 / 3);
   });
 
   it('handles an all-zero (never won) history', () => {
@@ -575,7 +596,8 @@ describe('buildShareSummary', () => {
 
     expect(summary).toContain('4 rounds tracked');
     expect(summary).toContain('Total won: 23 units');
-    expect(summary).toContain('Best round: #1 (10 units)');
+    expect(summary).toContain('ROI:');
+    expect(summary).toContain('Best round: #1 (10 units) - https://neofood.club/#round=1');
     expect(summary).toContain('Current streak: 1 win (8 units)');
     expect(summary).toContain('Longest win streak: 2 (15 units)');
   });

--- a/src/app/analysis/fcDataStats.ts
+++ b/src/app/analysis/fcDataStats.ts
@@ -32,6 +32,10 @@ export interface FcDataTotals {
   averageUnitsPerRound: number;
   /** Fraction of rounds with unitsWon > 0, 0..1. */
   winRate: number;
+  /** Sum of active bet lines (see `activeBetLineCount`) across every recorded round. */
+  totalActiveBetLines: number;
+  /** totalUnitsWon / totalActiveBetLines, all-time. 1.0 means breaking even. */
+  roi: number;
   /** Highest unitsWon; first occurrence wins ties. Null when there are no rows. */
   bestRound: FcDataRow | null;
   /** Null when no round ever won anything. */
@@ -348,6 +352,8 @@ export function computeTotals(rows: FcDataRow[]): FcDataTotals {
       totalUnitsWon: 0,
       averageUnitsPerRound: 0,
       winRate: 0,
+      totalActiveBetLines: 0,
+      roi: 0,
       bestRound: null,
       longestWinStreak: null,
       longestLossStreak: null,
@@ -359,6 +365,7 @@ export function computeTotals(rows: FcDataRow[]): FcDataTotals {
 
   const totalUnitsWon = rows.reduce((sum, row) => sum + row.unitsWon, 0);
   const winningRounds = rows.filter(row => row.unitsWon > 0).length;
+  const totalActiveBetLines = rows.reduce((sum, row) => sum + activeBetLineCount(row.url), 0);
 
   let bestRound = rows[0]!;
   for (const row of rows) {
@@ -372,6 +379,8 @@ export function computeTotals(rows: FcDataRow[]): FcDataTotals {
     totalUnitsWon,
     averageUnitsPerRound: totalUnitsWon / rows.length,
     winRate: winningRounds / rows.length,
+    totalActiveBetLines,
+    roi: totalActiveBetLines > 0 ? totalUnitsWon / totalActiveBetLines : 0,
     bestRound,
     longestWinStreak: longestWinStreak(rows),
     longestLossStreak: longestLossStreak(rows),
@@ -543,12 +552,12 @@ export function buildShareSummary(totals: FcDataTotals): string {
 
   const lines: string[] = [
     `NeoFoodClub stats: ${totals.roundsRecorded.toLocaleString()} rounds tracked`,
-    `Total won: ${Math.round(totals.totalUnitsWon).toLocaleString()} units | Win rate: ${(totals.winRate * 100).toFixed(1)}% | Avg/round: ${totals.averageUnitsPerRound.toFixed(1)}`,
+    `Total won: ${Math.round(totals.totalUnitsWon).toLocaleString()} units | Win rate: ${(totals.winRate * 100).toFixed(1)}% | Avg/round: ${totals.averageUnitsPerRound.toFixed(1)} | ROI: ${totals.roi.toFixed(3)}x`,
   ];
 
   if (totals.bestRound) {
     lines.push(
-      `Best round: #${totals.bestRound.round} (${Math.round(totals.bestRound.unitsWon).toLocaleString()} units)`,
+      `Best round: #${totals.bestRound.round} (${Math.round(totals.bestRound.unitsWon).toLocaleString()} units) - ${totals.bestRound.url}`,
     );
   }
 

--- a/src/app/analysis/fcDataStats.ts
+++ b/src/app/analysis/fcDataStats.ts
@@ -552,7 +552,7 @@ export function buildShareSummary(totals: FcDataTotals): string {
 
   const lines: string[] = [
     `NeoFoodClub stats: ${totals.roundsRecorded.toLocaleString()} rounds tracked`,
-    `Total won: ${Math.round(totals.totalUnitsWon).toLocaleString()} units | Win rate: ${(totals.winRate * 100).toFixed(1)}% | Avg/round: ${totals.averageUnitsPerRound.toFixed(1)} | ROI: ${totals.roi.toFixed(3)}x`,
+    `Total won: ${Math.round(totals.totalUnitsWon).toLocaleString()} units | Win rate: ${(totals.winRate * 100).toFixed(1)}% | ROI: ${totals.roi.toFixed(3)}x`,
   ];
 
   if (totals.bestRound) {

--- a/src/app/components/modals/FcDataModal.tsx
+++ b/src/app/components/modals/FcDataModal.tsx
@@ -166,7 +166,6 @@ function FcDataTotalsSection({ totals }: { totals: FcDataTotals }): React.JSX.El
           value={formatUnits(totals.totalUnitsWon)}
           color="nfc-blue.600"
         />
-        <StatBlock label="Average per round" value={totals.averageUnitsPerRound.toFixed(1)} />
         <StatBlock
           label="ROI"
           value={formatRoi(totals.roi)}

--- a/src/app/components/modals/FcDataModal.tsx
+++ b/src/app/components/modals/FcDataModal.tsx
@@ -168,6 +168,12 @@ function FcDataTotalsSection({ totals }: { totals: FcDataTotals }): React.JSX.El
         />
         <StatBlock label="Average per round" value={totals.averageUnitsPerRound.toFixed(1)} />
         <StatBlock
+          label="ROI"
+          value={formatRoi(totals.roi)}
+          sub="units won per active bet line"
+          color={roiColor(totals.roi)}
+        />
+        <StatBlock
           label="Win rate"
           value={displayPercent(totals.winRate)}
           color={totals.winRate >= 0.5 ? 'green.600' : 'orange.500'}


### PR DESCRIPTION
## Summary
- Add an ROI stat tile to the FC Data Visualizer's Overview section, matching the ROI already shown in the yearly/monthly tables and ROI chart (units won per active bet line).
- Add ROI to the "Copy Summary" Discord-friendly text blurb.
- Make the summary's "Best round" reference a full URL (instead of just the round number) so it renders as a clickable link when pasted elsewhere.