### PR TITLE
Add a download button for previous.jsonl to the View Round JSON dev tool

### DIFF
--- a/src/app/components/modals/RoundJsonModal.tsx
+++ b/src/app/components/modals/RoundJsonModal.tsx
@@ -250,12 +250,14 @@ export const RoundJsonModal: React.FC<RoundJsonModalProps> = ({ isOpen, onClose 
                   <Text fontSize="xs" color="fg.muted">
                     Current round on Neopets: {currentRoundFromCdn > 0 ? currentRoundFromCdn : '—'}
                   </Text>
-                  <RoundInput
-                    selectedRound={previewRound}
-                    referenceRound={currentRoundFromCdn}
-                    onRoundChange={setPreviewRound}
-                    hasError={previewError !== null}
-                  />
+                  <Box maxW="170px">
+                    <RoundInput
+                      selectedRound={previewRound}
+                      referenceRound={currentRoundFromCdn}
+                      onRoundChange={setPreviewRound}
+                      hasError={previewError !== null}
+                    />
+                  </Box>
                 </Stack>
                 <HStack justify="space-between" flexWrap="wrap" gap={2}>
                   <Text fontSize="xs" color="fg.muted">
@@ -263,7 +265,8 @@ export const RoundJsonModal: React.FC<RoundJsonModalProps> = ({ isOpen, onClose 
                   </Text>
                   <Button
                     size="xs"
-                    variant="outline"
+                    variant="solid"
+                    colorPalette="nfc-green"
                     onClick={handleDownloadPreviousJsonl}
                     disabled={downloadStatus === 'downloading'}
                   >

--- a/src/app/components/modals/RoundJsonModal.tsx
+++ b/src/app/components/modals/RoundJsonModal.tsx
@@ -14,11 +14,12 @@ import {
   Text,
 } from '@chakra-ui/react';
 import * as React from 'react';
-import { FaCode } from 'react-icons/fa';
+import { FaCode, FaDownload } from 'react-icons/fa';
 import type { HighlighterGeneric } from 'shiki';
 
 import { defaultRoundData } from '../../constants';
 import { useCurrentRound, useRoundStore } from '../../stores';
+import { downloadBlob } from '../../util/downloadFile';
 import RoundInput from '../inputs/RoundInput';
 
 import { RoundData } from '@/types';
@@ -143,6 +144,25 @@ export const RoundJsonModal: React.FC<RoundJsonModalProps> = ({ isOpen, onClose 
   const [previewLoading, setPreviewLoading] = React.useState(false);
   const [previewError, setPreviewError] = React.useState<string | null>(null);
 
+  const [downloadStatus, setDownloadStatus] = React.useState<'idle' | 'downloading' | 'error'>(
+    'idle',
+  );
+
+  const handleDownloadPreviousJsonl = React.useCallback(async (): Promise<void> => {
+    setDownloadStatus('downloading');
+    try {
+      const response = await fetch('https://cdn.neofood.club/previous.jsonl');
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      downloadBlob(await response.blob(), 'previous.jsonl');
+      setDownloadStatus('idle');
+    } catch (error) {
+      console.error('Failed to download previous.jsonl:', error);
+      setDownloadStatus('error');
+    }
+  }, []);
+
   // Reset the preview to the live round each time the modal opens. Runs as a
   // layout effect so the reset is committed before the fetch effect below
   // sees `previewRound` in this same pass - otherwise the fetch effect would
@@ -237,6 +257,28 @@ export const RoundJsonModal: React.FC<RoundJsonModalProps> = ({ isOpen, onClose 
                     hasError={previewError !== null}
                   />
                 </Stack>
+                <HStack justify="space-between" flexWrap="wrap" gap={2}>
+                  <Text fontSize="xs" color="fg.muted">
+                    Download the full previous-rounds history feed (~13MB) used by the backtesting
+                    tools.
+                  </Text>
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    onClick={handleDownloadPreviousJsonl}
+                    disabled={downloadStatus === 'downloading'}
+                  >
+                    <FaDownload />
+                    {downloadStatus === 'downloading'
+                      ? 'Downloading...'
+                      : 'Download previous.jsonl'}
+                  </Button>
+                </HStack>
+                {downloadStatus === 'error' && (
+                  <Text fontSize="xs" color="fg.error">
+                    Failed to download previous.jsonl.
+                  </Text>
+                )}
                 <Box minH="300px" opacity={previewLoading ? 0.6 : 1} transition="opacity 0.15s">
                   {previewError ? (
                     <Text fontSize="sm" color="nfc-red.fg">

--- a/src/app/components/modals/RoundJsonModal.tsx
+++ b/src/app/components/modals/RoundJsonModal.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Button,
+  Card,
   Dialog,
   Portal,
   CloseButton,
@@ -243,44 +244,49 @@ export const RoundJsonModal: React.FC<RoundJsonModalProps> = ({ isOpen, onClose 
             </Dialog.Header>
             <Dialog.Body>
               <Stack gap={3}>
-                <Stack gap={1} align="stretch">
-                  <Text fontSize="sm" fontWeight="medium">
-                    Change round
-                  </Text>
-                  <Text fontSize="xs" color="fg.muted">
-                    Current round on Neopets: {currentRoundFromCdn > 0 ? currentRoundFromCdn : '—'}
-                  </Text>
-                  <HStack justify="space-between" flexWrap="wrap" gap={2}>
-                    <Box maxW="170px">
-                      <RoundInput
-                        selectedRound={previewRound}
-                        referenceRound={currentRoundFromCdn}
-                        onRoundChange={setPreviewRound}
-                        hasError={previewError !== null}
-                      />
-                    </Box>
-                    <Button
-                      size="xs"
-                      variant="solid"
-                      colorPalette="nfc-green"
-                      onClick={handleDownloadPreviousJsonl}
-                      disabled={downloadStatus === 'downloading'}
-                    >
-                      <FaDownload />
-                      {downloadStatus === 'downloading'
-                        ? 'Downloading...'
-                        : 'Download previous.jsonl'}
-                    </Button>
-                  </HStack>
-                  <Text fontSize="xs" color="fg.muted">
-                    Download the full previous-rounds history feed (~13MB).
-                  </Text>
-                </Stack>
-                {downloadStatus === 'error' && (
-                  <Text fontSize="xs" color="fg.error">
-                    Failed to download previous.jsonl.
-                  </Text>
-                )}
+                <Card.Root boxShadow="sm">
+                  <Card.Body p={3}>
+                    <Stack gap={2} align="stretch">
+                      <Text fontSize="sm" fontWeight="medium">
+                        Change round
+                      </Text>
+                      <Text fontSize="xs" color="fg.muted">
+                        Current round on Neopets:{' '}
+                        {currentRoundFromCdn > 0 ? currentRoundFromCdn : '—'}
+                      </Text>
+                      <HStack justify="space-between" flexWrap="wrap" gap={2}>
+                        <Box maxW="170px">
+                          <RoundInput
+                            selectedRound={previewRound}
+                            referenceRound={currentRoundFromCdn}
+                            onRoundChange={setPreviewRound}
+                            hasError={previewError !== null}
+                          />
+                        </Box>
+                        <Button
+                          size="xs"
+                          variant="solid"
+                          colorPalette="nfc-green"
+                          onClick={handleDownloadPreviousJsonl}
+                          disabled={downloadStatus === 'downloading'}
+                        >
+                          <FaDownload />
+                          {downloadStatus === 'downloading'
+                            ? 'Downloading...'
+                            : 'Download previous.jsonl'}
+                        </Button>
+                      </HStack>
+                      <Text fontSize="xs" color="fg.muted">
+                        Download the full previous-rounds history feed (~13MB).
+                      </Text>
+                      {downloadStatus === 'error' && (
+                        <Text fontSize="xs" color="fg.error">
+                          Failed to download previous.jsonl.
+                        </Text>
+                      )}
+                    </Stack>
+                  </Card.Body>
+                </Card.Root>
                 <Box minH="300px" opacity={previewLoading ? 0.6 : 1} transition="opacity 0.15s">
                   {previewError ? (
                     <Text fontSize="sm" color="nfc-red.fg">

--- a/src/app/components/modals/RoundJsonModal.tsx
+++ b/src/app/components/modals/RoundJsonModal.tsx
@@ -250,40 +250,44 @@ export const RoundJsonModal: React.FC<RoundJsonModalProps> = ({ isOpen, onClose 
                       <Text fontSize="sm" fontWeight="medium">
                         Change round
                       </Text>
-                      <Text fontSize="xs" color="fg.muted">
-                        Current round on Neopets:{' '}
-                        {currentRoundFromCdn > 0 ? currentRoundFromCdn : '—'}
-                      </Text>
-                      <HStack justify="space-between" flexWrap="wrap" gap={2}>
-                        <Box maxW="170px">
-                          <RoundInput
-                            selectedRound={previewRound}
-                            referenceRound={currentRoundFromCdn}
-                            onRoundChange={setPreviewRound}
-                            hasError={previewError !== null}
-                          />
-                        </Box>
-                        <Button
-                          size="xs"
-                          variant="solid"
-                          colorPalette="nfc-green"
-                          onClick={handleDownloadPreviousJsonl}
-                          disabled={downloadStatus === 'downloading'}
-                        >
-                          <FaDownload />
-                          {downloadStatus === 'downloading'
-                            ? 'Downloading...'
-                            : 'Download previous.jsonl'}
-                        </Button>
+                      <HStack justify="space-between" align="flex-start" flexWrap="wrap" gap={4}>
+                        <Stack gap={1}>
+                          <Text fontSize="xs" color="fg.muted">
+                            Current round on Neopets:{' '}
+                            {currentRoundFromCdn > 0 ? currentRoundFromCdn : '—'}
+                          </Text>
+                          <Box maxW="170px">
+                            <RoundInput
+                              selectedRound={previewRound}
+                              referenceRound={currentRoundFromCdn}
+                              onRoundChange={setPreviewRound}
+                              hasError={previewError !== null}
+                            />
+                          </Box>
+                        </Stack>
+                        <Stack gap={1} align="flex-end">
+                          <Button
+                            size="xs"
+                            variant="solid"
+                            colorPalette="nfc-green"
+                            onClick={handleDownloadPreviousJsonl}
+                            disabled={downloadStatus === 'downloading'}
+                          >
+                            <FaDownload />
+                            {downloadStatus === 'downloading'
+                              ? 'Downloading...'
+                              : 'Download previous.jsonl'}
+                          </Button>
+                          <Text fontSize="xs" color="fg.muted" textAlign="right">
+                            Download the full previous-rounds history feed (~13MB).
+                          </Text>
+                          {downloadStatus === 'error' && (
+                            <Text fontSize="xs" color="fg.error" textAlign="right">
+                              Failed to download previous.jsonl.
+                            </Text>
+                          )}
+                        </Stack>
                       </HStack>
-                      <Text fontSize="xs" color="fg.muted">
-                        Download the full previous-rounds history feed (~13MB).
-                      </Text>
-                      {downloadStatus === 'error' && (
-                        <Text fontSize="xs" color="fg.error">
-                          Failed to download previous.jsonl.
-                        </Text>
-                      )}
                     </Stack>
                   </Card.Body>
                 </Card.Root>

--- a/src/app/components/modals/RoundJsonModal.tsx
+++ b/src/app/components/modals/RoundJsonModal.tsx
@@ -259,8 +259,7 @@ export const RoundJsonModal: React.FC<RoundJsonModalProps> = ({ isOpen, onClose 
                 </Stack>
                 <HStack justify="space-between" flexWrap="wrap" gap={2}>
                   <Text fontSize="xs" color="fg.muted">
-                    Download the full previous-rounds history feed (~13MB) used by the backtesting
-                    tools.
+                    Download the full previous-rounds history feed (~13MB).
                   </Text>
                   <Button
                     size="xs"

--- a/src/app/components/modals/RoundJsonModal.tsx
+++ b/src/app/components/modals/RoundJsonModal.tsx
@@ -244,53 +244,58 @@ export const RoundJsonModal: React.FC<RoundJsonModalProps> = ({ isOpen, onClose 
             </Dialog.Header>
             <Dialog.Body>
               <Stack gap={3}>
-                <Card.Root boxShadow="sm">
-                  <Card.Body p={3}>
-                    <Stack gap={2} align="stretch">
-                      <Text fontSize="sm" fontWeight="medium">
-                        Change round
-                      </Text>
-                      <HStack justify="space-between" align="flex-start" flexWrap="wrap" gap={4}>
-                        <Stack gap={1}>
-                          <Text fontSize="xs" color="fg.muted">
-                            Current round on Neopets:{' '}
-                            {currentRoundFromCdn > 0 ? currentRoundFromCdn : '—'}
+                <HStack align="stretch" flexWrap="wrap" gap={3}>
+                  <Card.Root boxShadow="sm" flex="1" minW="200px">
+                    <Card.Body p={3}>
+                      <Stack gap={1}>
+                        <Text fontSize="sm" fontWeight="medium">
+                          Change round
+                        </Text>
+                        <Text fontSize="xs" color="fg.muted">
+                          Current round on Neopets:{' '}
+                          {currentRoundFromCdn > 0 ? currentRoundFromCdn : '—'}
+                        </Text>
+                        <Box maxW="170px">
+                          <RoundInput
+                            selectedRound={previewRound}
+                            referenceRound={currentRoundFromCdn}
+                            onRoundChange={setPreviewRound}
+                            hasError={previewError !== null}
+                          />
+                        </Box>
+                      </Stack>
+                    </Card.Body>
+                  </Card.Root>
+                  <Card.Root boxShadow="sm" flex="1" minW="200px">
+                    <Card.Body p={3}>
+                      <Stack gap={1}>
+                        <Text fontSize="sm" fontWeight="medium">
+                          Download history
+                        </Text>
+                        <Text fontSize="xs" color="fg.muted">
+                          Download the full previous-rounds history feed (~13MB).
+                        </Text>
+                        <Button
+                          size="xs"
+                          variant="solid"
+                          colorPalette="nfc-green"
+                          onClick={handleDownloadPreviousJsonl}
+                          disabled={downloadStatus === 'downloading'}
+                        >
+                          <FaDownload />
+                          {downloadStatus === 'downloading'
+                            ? 'Downloading...'
+                            : 'Download previous.jsonl'}
+                        </Button>
+                        {downloadStatus === 'error' && (
+                          <Text fontSize="xs" color="fg.error">
+                            Failed to download previous.jsonl.
                           </Text>
-                          <Box maxW="170px">
-                            <RoundInput
-                              selectedRound={previewRound}
-                              referenceRound={currentRoundFromCdn}
-                              onRoundChange={setPreviewRound}
-                              hasError={previewError !== null}
-                            />
-                          </Box>
-                        </Stack>
-                        <Stack gap={1} align="flex-end">
-                          <Button
-                            size="xs"
-                            variant="solid"
-                            colorPalette="nfc-green"
-                            onClick={handleDownloadPreviousJsonl}
-                            disabled={downloadStatus === 'downloading'}
-                          >
-                            <FaDownload />
-                            {downloadStatus === 'downloading'
-                              ? 'Downloading...'
-                              : 'Download previous.jsonl'}
-                          </Button>
-                          <Text fontSize="xs" color="fg.muted" textAlign="right">
-                            Download the full previous-rounds history feed (~13MB).
-                          </Text>
-                          {downloadStatus === 'error' && (
-                            <Text fontSize="xs" color="fg.error" textAlign="right">
-                              Failed to download previous.jsonl.
-                            </Text>
-                          )}
-                        </Stack>
-                      </HStack>
-                    </Stack>
-                  </Card.Body>
-                </Card.Root>
+                        )}
+                      </Stack>
+                    </Card.Body>
+                  </Card.Root>
+                </HStack>
                 <Box minH="300px" opacity={previewLoading ? 0.6 : 1} transition="opacity 0.15s">
                   {previewError ? (
                     <Text fontSize="sm" color="nfc-red.fg">

--- a/src/app/components/modals/RoundJsonModal.tsx
+++ b/src/app/components/modals/RoundJsonModal.tsx
@@ -250,32 +250,32 @@ export const RoundJsonModal: React.FC<RoundJsonModalProps> = ({ isOpen, onClose 
                   <Text fontSize="xs" color="fg.muted">
                     Current round on Neopets: {currentRoundFromCdn > 0 ? currentRoundFromCdn : '—'}
                   </Text>
-                  <Box maxW="170px">
-                    <RoundInput
-                      selectedRound={previewRound}
-                      referenceRound={currentRoundFromCdn}
-                      onRoundChange={setPreviewRound}
-                      hasError={previewError !== null}
-                    />
-                  </Box>
-                </Stack>
-                <HStack justify="space-between" flexWrap="wrap" gap={2}>
+                  <HStack justify="space-between" flexWrap="wrap" gap={2}>
+                    <Box maxW="170px">
+                      <RoundInput
+                        selectedRound={previewRound}
+                        referenceRound={currentRoundFromCdn}
+                        onRoundChange={setPreviewRound}
+                        hasError={previewError !== null}
+                      />
+                    </Box>
+                    <Button
+                      size="xs"
+                      variant="solid"
+                      colorPalette="nfc-green"
+                      onClick={handleDownloadPreviousJsonl}
+                      disabled={downloadStatus === 'downloading'}
+                    >
+                      <FaDownload />
+                      {downloadStatus === 'downloading'
+                        ? 'Downloading...'
+                        : 'Download previous.jsonl'}
+                    </Button>
+                  </HStack>
                   <Text fontSize="xs" color="fg.muted">
                     Download the full previous-rounds history feed (~13MB).
                   </Text>
-                  <Button
-                    size="xs"
-                    variant="solid"
-                    colorPalette="nfc-green"
-                    onClick={handleDownloadPreviousJsonl}
-                    disabled={downloadStatus === 'downloading'}
-                  >
-                    <FaDownload />
-                    {downloadStatus === 'downloading'
-                      ? 'Downloading...'
-                      : 'Download previous.jsonl'}
-                  </Button>
-                </HStack>
+                </Stack>
                 {downloadStatus === 'error' && (
                   <Text fontSize="xs" color="fg.error">
                     Failed to download previous.jsonl.

--- a/src/app/util/__tests__/downloadFile.test.ts
+++ b/src/app/util/__tests__/downloadFile.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { downloadBlob } from '../downloadFile';
+
+describe('downloadBlob', () => {
+  let clickSpy: ReturnType<typeof vi.spyOn>;
+  let createObjectURLSpy: ReturnType<typeof vi.spyOn>;
+  let revokeObjectURLSpy: ReturnType<typeof vi.spyOn>;
+  let capturedHref: string | undefined;
+  let capturedDownload: string | undefined;
+
+  beforeEach(() => {
+    capturedHref = undefined;
+    capturedDownload = undefined;
+    createObjectURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock-url');
+    revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+      this: HTMLAnchorElement,
+    ) {
+      capturedHref = this.href;
+      capturedDownload = this.download;
+    });
+  });
+
+  afterEach(() => {
+    clickSpy.mockRestore();
+    createObjectURLSpy.mockRestore();
+    revokeObjectURLSpy.mockRestore();
+  });
+
+  it('creates an object URL, clicks a throwaway anchor with it, then revokes it', () => {
+    const blob = new Blob(['hello'], { type: 'text/plain' });
+
+    downloadBlob(blob, 'previous.jsonl');
+
+    expect(createObjectURLSpy).toHaveBeenCalledWith(blob);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(capturedHref).toBe('blob:mock-url');
+    expect(capturedDownload).toBe('previous.jsonl');
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:mock-url');
+  });
+});

--- a/src/app/util/downloadFile.ts
+++ b/src/app/util/downloadFile.ts
@@ -1,0 +1,9 @@
+/** Triggers a browser "Save As" for the given blob using a throwaway object URL. */
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- Add a "Download previous.jsonl" button to the dev drawer's "View Round JSON" tool, so the full previous-rounds history feed (~13MB) used by the backtesting tools can be grabbed directly, without needing to open one of the tools that fetches it behind the scenes.
- Add a small reusable `downloadBlob` helper (`src/app/util/downloadFile.ts`) - no browser file-download utility existed in the codebase before this.