### PR TITLE
Add documented types for previous.jsonl's schema

### DIFF
--- a/src/app/data/previousRoundsFeed.ts
+++ b/src/app/data/previousRoundsFeed.ts
@@ -1,10 +1,32 @@
+/** One arena's four pirate IDs, 0-indexed by `position - 1`. */
+export type ArenaPirateIds = [number, number, number, number];
+
+/**
+ * One arena's odds, indexed 0-4: index 0 is an unused "no pick" placeholder,
+ * indices 1-4 are the odds for that arena's four pirates - the same
+ * 1-indexed convention used by odds/probability arrays elsewhere in this app.
+ */
+export type ArenaOddsRow = [number, number, number, number, number];
+
+/** One line of `previous.jsonl`: a single NeoFoodClub round's pirates, odds, and result. */
 export interface RawPreviousRoundLine {
   round: number;
-  pirates: number[][];
-  openingOdds: number[][];
-  currentOdds: number[][];
+  /** One entry per arena (5 total). */
+  pirates: ArenaPirateIds[];
+  /** One entry per arena (5 total): odds at the start of the round. */
+  openingOdds: ArenaOddsRow[];
+  /** One entry per arena (5 total): odds as of when this line was recorded. */
+  currentOdds: ArenaOddsRow[];
+  /**
+   * Winning position (1-4) per arena, 5 entries, in arena order. A value of
+   * 0 means no result was recorded for that arena (round still in progress,
+   * or data never captured) - see `fetchPreviousRounds` in
+   * `../backtest/previousRounds.ts`, which filters these rows out entirely.
+   */
   winners?: number[] | null;
+  /** Food item IDs served in each arena that round, when available. */
   foods?: number[][] | null;
+  /** ISO 8601 timestamp of when this line was recorded, when available. */
   timestamp?: string | null;
 }
 


### PR DESCRIPTION
## Summary
- Stacked on #1016.
- Replace the bare `number[][]` fields on `RawPreviousRoundLine` (the type describing one parsed line of `previous.jsonl`) with named, documented types: `ArenaPirateIds` and `ArenaOddsRow`, plus field-level JSDoc explaining indexing conventions and what a `0` in `winners` means.
- Scope is limited to this one interface (the actual previous.jsonl schema); `BacktestRound` is a separate, already-filtered type used elsewhere and needs no changes since tuple types are structurally assignable to `number[][]`.