### PR TITLE
Add Wasm engine perf panel to dev mode

### DIFF
--- a/src/app/components/dev/DevModeDrawer.tsx
+++ b/src/app/components/dev/DevModeDrawer.tsx
@@ -8,7 +8,7 @@ import {
   FaStopwatch,
   FaTable,
 } from 'react-icons/fa';
-import { FaMagnifyingGlassChart } from 'react-icons/fa6';
+import { FaGauge, FaMagnifyingGlassChart } from 'react-icons/fa6';
 
 import { useDisclosureState } from '../../hooks/useDisclosureState';
 import { getReactScanEnabled, setReactScanEnabled } from '../../util/reactScan';
@@ -18,6 +18,7 @@ import { FcDataModal } from '../modals/FcDataModal';
 import { PirateMatchupModal } from '../modals/PirateMatchupModal';
 import { RoundEndDriftModal } from '../modals/RoundEndDriftModal';
 import { RoundJsonModal } from '../modals/RoundJsonModal';
+import { WasmEnginePerfModal } from '../modals/WasmEnginePerfModal';
 import SettingsSwitch from '../TableSettings/SettingsSwitch';
 
 interface DevModeDrawerProps {
@@ -29,6 +30,7 @@ export const DevModeDrawer: React.FC<DevModeDrawerProps> = ({ isOpen, onClose })
   const jsonModal = useDisclosureState(false);
   const allBetsModal = useDisclosureState(false);
   const backtestModal = useDisclosureState(false);
+  const perfModal = useDisclosureState(false);
   const driftModal = useDisclosureState(false);
   const matchupModal = useDisclosureState(false);
   const fcDataModal = useDisclosureState(false);
@@ -82,6 +84,10 @@ export const DevModeDrawer: React.FC<DevModeDrawerProps> = ({ isOpen, onClose })
                     <FaBalanceScale />
                     Compare Max-TER Models
                   </Button>
+                  <Button width="full" onClick={perfModal.onOpen}>
+                    <FaGauge />
+                    Wasm Engine Perf
+                  </Button>
                   <Button width="full" onClick={driftModal.onOpen}>
                     <FaStopwatch />
                     Round End-Time Drift
@@ -112,6 +118,7 @@ export const DevModeDrawer: React.FC<DevModeDrawerProps> = ({ isOpen, onClose })
       <RoundEndDriftModal isOpen={driftModal.isOpen} onClose={driftModal.onClose} />
       <PirateMatchupModal isOpen={matchupModal.isOpen} onClose={matchupModal.onClose} />
       <FcDataModal isOpen={fcDataModal.isOpen} onClose={fcDataModal.onClose} />
+      <WasmEnginePerfModal isOpen={perfModal.isOpen} onClose={perfModal.onClose} />
     </>
   );
 };

--- a/src/app/components/modals/WasmEnginePerfModal.tsx
+++ b/src/app/components/modals/WasmEnginePerfModal.tsx
@@ -1,0 +1,407 @@
+import {
+  Button,
+  Checkbox,
+  Dialog,
+  CloseButton,
+  HStack,
+  Input,
+  Portal,
+  Progress,
+  SegmentGroup,
+  Stack,
+  Table,
+  Text,
+} from '@chakra-ui/react';
+import * as React from 'react';
+import { FaGauge } from 'react-icons/fa6';
+
+import { defaultRoundData } from '../../constants';
+import {
+  PERF_BET_COUNT,
+  runEnginePerfSuite,
+  type EnginePerfResult,
+} from '../../perf/wasmEnginePerf';
+import { useCurrentRound, useRoundStore } from '../../stores';
+import { applyCustomOdds, applyCustomProbabilities, rebuildEngine } from '../../wasmEngine';
+import RoundInput from '../inputs/RoundInput';
+
+import type { RoundData } from '@/types';
+
+interface WasmEnginePerfModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const ITERATION_OPTIONS = [10, 50, 100, 500] as const;
+const DEFAULT_ITERATIONS = 10;
+const DEFAULT_BET_AMOUNT = 10000;
+
+interface RunState {
+  running: boolean;
+  done: number;
+  total: number;
+  results: EnginePerfResult[] | null;
+  error: string | null;
+}
+
+const INITIAL_RUN_STATE: RunState = {
+  running: false,
+  done: 0,
+  total: 0,
+  results: null,
+  error: null,
+};
+
+function isAbortError(err: unknown): boolean {
+  return (
+    (err instanceof DOMException && err.name === 'AbortError') ||
+    (typeof err === 'object' && err !== null && (err as { name?: string }).name === 'AbortError')
+  );
+}
+
+function formatMs(value: number): string {
+  if (value >= 10) {
+    return value.toFixed(2);
+  }
+  if (value >= 1) {
+    return value.toFixed(3);
+  }
+  return value.toFixed(4);
+}
+
+export const WasmEnginePerfModal: React.FC<WasmEnginePerfModalProps> = ({ isOpen, onClose }) => {
+  const roundData = useRoundStore(state => state.roundData);
+  const currentSelectedRound = useRoundStore(state => state.currentSelectedRound);
+  const currentRoundFromCdn = useCurrentRound();
+
+  // The round being timed - independent of the globally selected round, so
+  // jumping ahead here never touches the rest of the page (same pattern as
+  // RoundJsonModal).
+  const [previewRound, setPreviewRound] = React.useState(0);
+  const [previewData, setPreviewData] = React.useState<RoundData | null>(null);
+  const [previewLoading, setPreviewLoading] = React.useState(false);
+  const [previewError, setPreviewError] = React.useState<string | null>(null);
+
+  // Reset the preview to the live round each time the modal opens. Runs as a
+  // layout effect so the reset is committed before the fetch effect below sees
+  // `previewRound` in this same pass.
+  React.useLayoutEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    setPreviewRound(currentSelectedRound);
+    setPreviewData(null);
+    setPreviewError(null);
+  }, [isOpen, currentSelectedRound]);
+
+  // Fetch the previewed round's JSON directly whenever it differs from the
+  // round already loaded globally.
+  React.useEffect(() => {
+    if (!isOpen || previewRound === 0 || previewRound === roundData.round) {
+      setPreviewLoading(false);
+      setPreviewError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    setPreviewLoading(true);
+    setPreviewError(null);
+
+    fetch(`https://cdn.neofood.club/rounds/${previewRound}.json`, { signal: controller.signal })
+      .then(response => {
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        return response.json() as Promise<RoundData>;
+      })
+      .then(data => {
+        setPreviewData(data);
+        setPreviewLoading(false);
+      })
+      .catch(error => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        console.error(`Failed to fetch round ${previewRound}:`, error);
+        setPreviewError(`Failed to fetch round ${previewRound}`);
+        setPreviewLoading(false);
+      });
+
+    return (): void => controller.abort();
+  }, [isOpen, previewRound, roundData.round]);
+
+  const displayedRoundData: RoundData | null =
+    previewRound === roundData.round ? roundData : (previewData ?? defaultRoundData);
+
+  const [iterations, setIterations] = React.useState<number>(DEFAULT_ITERATIONS);
+  const [betAmountInput, setBetAmountInput] = React.useState(String(DEFAULT_BET_AMOUNT));
+  const [useLogit, setUseLogit] = React.useState(false);
+  const [runState, setRunState] = React.useState<RunState>(INITIAL_RUN_STATE);
+  const abortControllerRef = React.useRef<AbortController | null>(null);
+
+  const betAmount = React.useMemo(() => {
+    const value = Number(betAmountInput);
+    return !Number.isNaN(value) && value > 0 ? Math.round(value) : DEFAULT_BET_AMOUNT;
+  }, [betAmountInput]);
+
+  // The perf suite clobbers the app's shared wasm engine instance - rebuild it
+  // for whatever round/mode the app is actually showing, reapply any custom
+  // overrides, and recalculate so the table isn't left with stale numbers.
+  const restoreAppEngine = React.useCallback((): void => {
+    const state = useRoundStore.getState();
+    if (state.roundData === defaultRoundData || !state.roundData.pirates?.length) {
+      return; // the app has no round loaded - nothing to restore
+    }
+    try {
+      rebuildEngine(
+        JSON.stringify(state.roundData),
+        state.maxBet >= 1 ? state.maxBet : null,
+        state.useLogitModel,
+      );
+      if (state.customOddsMode) {
+        if (state.customOdds) {
+          applyCustomOdds(state.customOdds);
+        }
+        if (state.customProbs) {
+          applyCustomProbabilities(state.customProbs);
+        }
+      } else {
+        applyCustomOdds(null);
+        applyCustomProbabilities(null);
+      }
+    } catch (error) {
+      console.error('Failed to restore wasm engine after perf run:', error);
+    } finally {
+      state.recalculate();
+    }
+  }, []);
+
+  // Cancels an in-flight run if the modal closes mid-run.
+  React.useEffect(() => {
+    if (!isOpen) {
+      abortControllerRef.current?.abort();
+    }
+  }, [isOpen]);
+
+  const handleRun = React.useCallback((): void => {
+    if (!displayedRoundData?.pirates?.length) {
+      return;
+    }
+
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    setRunState({ running: true, done: 0, total: 0, results: null, error: null });
+
+    void runEnginePerfSuite({
+      roundJson: JSON.stringify(displayedRoundData),
+      useLogit,
+      betAmount,
+      iterations,
+      signal: controller.signal,
+      onProgress: (done, total) => {
+        setRunState(prev => ({ ...prev, done, total }));
+      },
+    })
+      .then(results => {
+        setRunState(prev => ({ ...prev, running: false, results }));
+      })
+      .catch((err: unknown) => {
+        if (isAbortError(err)) {
+          setRunState(INITIAL_RUN_STATE);
+          return;
+        }
+        setRunState(prev => ({ ...prev, running: false, error: String(err) }));
+      })
+      .finally(restoreAppEngine);
+  }, [displayedRoundData, useLogit, betAmount, iterations, restoreAppEngine]);
+
+  const handleCancel = React.useCallback((): void => {
+    abortControllerRef.current?.abort();
+  }, []);
+
+  const progressPercent =
+    runState.total > 0 ? Math.round((runState.done / runState.total) * 100) : 0;
+
+  return (
+    <Dialog.Root
+      open={isOpen}
+      onOpenChange={(e: { open: boolean }) => !e.open && onClose()}
+      size="xl"
+      preventScroll
+      modal
+    >
+      <Portal>
+        <Dialog.Backdrop />
+        <Dialog.Positioner>
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>Wasm Engine Perf</Dialog.Title>
+              <Dialog.CloseTrigger asChild>
+                <CloseButton size="sm" />
+              </Dialog.CloseTrigger>
+            </Dialog.Header>
+            <Dialog.Body display="flex" flexDirection="column" overflowY="auto">
+              <Stack gap={4}>
+                <Text fontSize="sm" color="fg.muted">
+                  Times each of the wasm engine&apos;s bet generators, repeated per operation on the
+                  round below. The app&apos;s own engine instance is temporarily rebuilt for this -
+                  it gets restored (and recalculated) when the run finishes.
+                </Text>
+
+                <Stack gap={1} align="stretch">
+                  <Text fontSize="sm" fontWeight="medium">
+                    Change round
+                  </Text>
+                  <RoundInput
+                    selectedRound={previewRound}
+                    referenceRound={currentRoundFromCdn}
+                    onRoundChange={setPreviewRound}
+                    hasError={previewError !== null}
+                  />
+                </Stack>
+
+                {previewError && (
+                  <Text fontSize="sm" color="nfc-red.fg">
+                    {previewError}
+                  </Text>
+                )}
+
+                <Stack gap={2}>
+                  <HStack>
+                    <Text fontSize="sm" fontWeight="medium" width="90px">
+                      Iterations:
+                    </Text>
+                    <SegmentGroup.Root
+                      value={String(iterations)}
+                      size="sm"
+                      onValueChange={(details: { value: string | null }) => {
+                        if (details.value === null) {
+                          return;
+                        }
+                        setIterations(Number(details.value));
+                      }}
+                      disabled={runState.running}
+                    >
+                      <SegmentGroup.Indicator />
+                      {ITERATION_OPTIONS.map(option => (
+                        <SegmentGroup.Item key={option} value={String(option)}>
+                          <SegmentGroup.ItemText>{option}</SegmentGroup.ItemText>
+                          <SegmentGroup.ItemHiddenInput />
+                        </SegmentGroup.Item>
+                      ))}
+                    </SegmentGroup.Root>
+                  </HStack>
+                  <HStack>
+                    <Text fontSize="sm" fontWeight="medium" width="90px">
+                      Bet Amount:
+                    </Text>
+                    <Input
+                      type="number"
+                      value={betAmountInput}
+                      onChange={e => setBetAmountInput(e.target.value)}
+                      width="140px"
+                      size="sm"
+                      disabled={runState.running}
+                    />
+                  </HStack>
+                  <HStack>
+                    <Text fontSize="sm" fontWeight="medium" width="90px">
+                      Model:
+                    </Text>
+                    <Checkbox.Root
+                      checked={useLogit}
+                      onCheckedChange={() => setUseLogit(prev => !prev)}
+                    >
+                      <Checkbox.HiddenInput />
+                      <Checkbox.Control />
+                      <Checkbox.Label>Experimental Logit</Checkbox.Label>
+                    </Checkbox.Root>
+                  </HStack>
+                </Stack>
+
+                <Text fontSize="xs" color="fg.muted" fontStyle="italic">
+                  Every operation generates {PERF_BET_COUNT} bets. Gambit uses pirate 1 in all five
+                  arenas; tenbet uses pirate 1 in the first three.
+                </Text>
+
+                <HStack gap={3}>
+                  <Button
+                    onClick={handleRun}
+                    disabled={
+                      runState.running || previewLoading || !displayedRoundData?.pirates?.length
+                    }
+                  >
+                    <FaGauge />
+                    Run Perf Suite
+                  </Button>
+                  {runState.running && (
+                    <Button variant="outline" onClick={handleCancel}>
+                      Cancel
+                    </Button>
+                  )}
+                </HStack>
+
+                {runState.running && (
+                  <Stack gap={1}>
+                    <Progress.Root value={progressPercent} size="sm" colorPalette="nfc-blue">
+                      <Progress.Track>
+                        <Progress.Range />
+                      </Progress.Track>
+                    </Progress.Root>
+                    <Text fontSize="xs" color="fg.muted">
+                      {runState.done} / {runState.total || '…'} operations ({progressPercent}%)
+                    </Text>
+                  </Stack>
+                )}
+
+                {runState.error && (
+                  <Text fontSize="sm" color="nfc-red.fg">
+                    {runState.error}
+                  </Text>
+                )}
+
+                {runState.results && (
+                  <Table.Root size="sm" width="full">
+                    <Table.Header>
+                      <Table.Row>
+                        <Table.ColumnHeader>Operation</Table.ColumnHeader>
+                        <Table.ColumnHeader textAlign="right">Min (ms)</Table.ColumnHeader>
+                        <Table.ColumnHeader textAlign="right">Avg (ms)</Table.ColumnHeader>
+                        <Table.ColumnHeader textAlign="right">Max (ms)</Table.ColumnHeader>
+                      </Table.Row>
+                    </Table.Header>
+                    <Table.Body>
+                      {runState.results.map(result => (
+                        <Table.Row key={result.operation}>
+                          <Table.Cell>{result.operation}</Table.Cell>
+                          {result.timing ? (
+                            <>
+                              <Table.Cell textAlign="right">
+                                {formatMs(result.timing.minMs)}
+                              </Table.Cell>
+                              <Table.Cell textAlign="right">
+                                {formatMs(result.timing.avgMs)}
+                              </Table.Cell>
+                              <Table.Cell textAlign="right">
+                                {formatMs(result.timing.maxMs)}
+                              </Table.Cell>
+                            </>
+                          ) : (
+                            <Table.Cell colSpan={3} color="fg.muted">
+                              skipped: {result.skippedReason ?? 'not applicable'}
+                            </Table.Cell>
+                          )}
+                        </Table.Row>
+                      ))}
+                    </Table.Body>
+                  </Table.Root>
+                )}
+              </Stack>
+            </Dialog.Body>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+    </Dialog.Root>
+  );
+};

--- a/src/app/components/modals/WasmEnginePerfModal.tsx
+++ b/src/app/components/modals/WasmEnginePerfModal.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   Checkbox,
   Dialog,
@@ -253,12 +254,14 @@ export const WasmEnginePerfModal: React.FC<WasmEnginePerfModalProps> = ({ isOpen
                   <Text fontSize="sm" fontWeight="medium">
                     Change round
                   </Text>
-                  <RoundInput
-                    selectedRound={previewRound}
-                    referenceRound={currentRoundFromCdn}
-                    onRoundChange={setPreviewRound}
-                    hasError={previewError !== null}
-                  />
+                  <Box maxW="170px">
+                    <RoundInput
+                      selectedRound={previewRound}
+                      referenceRound={currentRoundFromCdn}
+                      onRoundChange={setPreviewRound}
+                      hasError={previewError !== null}
+                    />
+                  </Box>
                 </Stack>
 
                 {previewError && (

--- a/src/app/components/modals/WasmEnginePerfModal.tsx
+++ b/src/app/components/modals/WasmEnginePerfModal.tsx
@@ -33,7 +33,7 @@ interface WasmEnginePerfModalProps {
   onClose: () => void;
 }
 
-const ITERATION_OPTIONS = [10, 50, 100, 500, 1000, 5000, 10000] as const;
+const ITERATION_OPTIONS = [10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000] as const;
 const DEFAULT_ITERATIONS = 10;
 const DEFAULT_BET_AMOUNT = 10000;
 

--- a/src/app/components/modals/WasmEnginePerfModal.tsx
+++ b/src/app/components/modals/WasmEnginePerfModal.tsx
@@ -37,6 +37,31 @@ const ITERATION_OPTIONS = [10, 50, 100, 500, 1000, 5000, 10000] as const;
 const DEFAULT_ITERATIONS = 10;
 const DEFAULT_BET_AMOUNT = 10000;
 
+const SEGMENT_GROUP_CSS = {
+  bg: 'bg.subtle',
+  borderWidth: '1px',
+  borderColor: 'border',
+  '& [data-state=unchecked]': {
+    color: 'fg.muted',
+  },
+  '& [data-state=checked]': {
+    color: 'fg',
+    fontWeight: 'semibold',
+  },
+  _dark: {
+    borderColor: 'border.emphasized',
+    '& [data-state=unchecked]': {
+      color: 'fg.subtle',
+    },
+  },
+  '& [data-part=indicator]': {
+    borderWidth: '1px',
+    borderColor: 'border',
+    bg: { base: 'bg', _dark: 'bg.emphasized' },
+    shadow: 'sm',
+  },
+} as const;
+
 interface RunState {
   running: boolean;
   done: number;
@@ -285,6 +310,7 @@ export const WasmEnginePerfModal: React.FC<WasmEnginePerfModalProps> = ({ isOpen
                         setIterations(Number(details.value));
                       }}
                       disabled={runState.running}
+                      css={SEGMENT_GROUP_CSS}
                     >
                       <SegmentGroup.Indicator />
                       {ITERATION_OPTIONS.map(option => (

--- a/src/app/components/modals/WasmEnginePerfModal.tsx
+++ b/src/app/components/modals/WasmEnginePerfModal.tsx
@@ -33,7 +33,7 @@ interface WasmEnginePerfModalProps {
   onClose: () => void;
 }
 
-const ITERATION_OPTIONS = [10, 50, 100, 500] as const;
+const ITERATION_OPTIONS = [10, 50, 100, 500, 1000, 5000, 10000] as const;
 const DEFAULT_ITERATIONS = 10;
 const DEFAULT_BET_AMOUNT = 10000;
 

--- a/src/app/perf/__tests__/wasmEnginePerf.test.ts
+++ b/src/app/perf/__tests__/wasmEnginePerf.test.ts
@@ -1,0 +1,185 @@
+import fs from 'fs';
+import path from 'path';
+
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import type { RoundData } from '../../../types';
+import * as wasmEngineModule from '../../wasmEngine';
+import { initWasmMath, wasmPiratesBinary } from '../../wasmMath';
+import {
+  deriveDefaultGambitBinary,
+  deriveDefaultTenbetBinary,
+  PERF_BET_COUNT,
+  runEnginePerfSuite,
+  timeOperation,
+} from '../wasmEnginePerf';
+
+// Spy on the engine rebuild so we can assert the suite (re)builds exactly once
+// per run - and that a pre-aborted signal doesn't touch the app's engine at all.
+vi.mock('../../wasmEngine', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../wasmEngine')>();
+  return { ...actual, rebuildEngine: vi.fn(actual.rebuildEngine) };
+});
+
+const fixturesPath = path.resolve(__dirname, '../../__tests__/fixtures/rounds.jsonl');
+const fixtureRounds: RoundData[] = fs
+  .readFileSync(fixturesPath, 'utf8')
+  .trim()
+  .split('\n')
+  .map(line => JSON.parse(line) as RoundData);
+
+const OPERATIONS = [
+  'makeMaxTerBets',
+  'makeGambitBets',
+  'makeWinningGambitBets',
+  'makeBestGambitBets',
+  'makeBustproofBets',
+  'makeCrazyBets',
+  'makeTenbetBets',
+];
+
+beforeAll(async () => {
+  await initWasmMath();
+});
+
+describe('timeOperation', () => {
+  it('invokes the function exactly `iterations` times and reports sane min/avg/max', () => {
+    let calls = 0;
+    const timing = timeOperation(() => {
+      calls++;
+    }, 25);
+
+    expect(calls).toBe(25);
+    expect(timing.minMs).toBeGreaterThanOrEqual(0);
+    expect(timing.minMs).toBeLessThanOrEqual(timing.avgMs);
+    expect(timing.avgMs).toBeLessThanOrEqual(timing.maxMs);
+  });
+
+  it('has min === max for a single iteration', () => {
+    const noop = vi.fn();
+    const timing = timeOperation(noop, 1);
+    expect(timing.minMs).toBe(timing.maxMs);
+    expect(timing.avgMs).toBe(timing.minMs);
+  });
+});
+
+describe('default binary derivation', () => {
+  it('gambit selects pirate index 1 in every arena (exactly one per arena)', () => {
+    expect(deriveDefaultGambitBinary()).toBe(wasmPiratesBinary([1, 1, 1, 1, 1]));
+  });
+
+  it('tenbet selects pirate index 1 in the first three arenas (<=3 pirates total)', () => {
+    expect(deriveDefaultTenbetBinary()).toBe(wasmPiratesBinary([1, 1, 0, 0, 0]));
+  });
+});
+
+describe('runEnginePerfSuite', () => {
+  const round = fixtureRounds[0]!;
+
+  it('rebuilds the engine once and times every operation for a round with winners', async () => {
+    vi.mocked(wasmEngineModule.rebuildEngine).mockClear();
+
+    const progressCalls: number[] = [];
+    const results = await runEnginePerfSuite({
+      roundJson: JSON.stringify(round),
+      useLogit: false,
+      betAmount: 10000,
+      iterations: 5,
+      onProgress: done => progressCalls.push(done),
+    });
+
+    expect(wasmEngineModule.rebuildEngine).toHaveBeenCalledTimes(1);
+    expect(wasmEngineModule.rebuildEngine).toHaveBeenCalledWith(
+      JSON.stringify(round),
+      10000,
+      false,
+    );
+
+    expect(results.map(r => r.operation)).toEqual(OPERATIONS);
+    expect(progressCalls).toEqual([1, 2, 3, 4, 5, 6, 7]);
+
+    for (const result of results) {
+      if (result.timing === null) {
+        expect(result.skippedReason).toBeTruthy();
+        continue;
+      }
+      const { minMs, avgMs, maxMs } = result.timing;
+      expect(minMs).toBeGreaterThanOrEqual(0);
+      expect(minMs).toBeLessThanOrEqual(avgMs);
+      expect(avgMs).toBeLessThanOrEqual(maxMs);
+    }
+
+    // A finished round must time (not skip) the winner-dependent operation.
+    const winningGambit = results.find(r => r.operation === 'makeWinningGambitBets')!;
+    expect(winningGambit.timing).not.toBeNull();
+  });
+
+  it('skips makeWinningGambitBets with a reason when the round has no winners yet', async () => {
+    const pendingRound = { ...round, winners: undefined };
+    const results = await runEnginePerfSuite({
+      roundJson: JSON.stringify(pendingRound),
+      useLogit: false,
+      betAmount: 10000,
+      iterations: 3,
+    });
+
+    const winningGambit = results.find(r => r.operation === 'makeWinningGambitBets')!;
+    expect(winningGambit.timing).toBeNull();
+    expect(winningGambit.skippedReason).toBeTruthy();
+
+    // The other operations are unaffected by missing winners.
+    for (const result of results.filter(r => r.operation !== 'makeWinningGambitBets')) {
+      expect(result.timing).not.toBeNull();
+    }
+  });
+
+  it('reports both logit and legacy runs without throwing', async () => {
+    for (const useLogit of [false, true]) {
+      const results = await runEnginePerfSuite({
+        roundJson: JSON.stringify(round),
+        useLogit,
+        betAmount: 25000,
+        iterations: 3,
+      });
+      expect(results).toHaveLength(OPERATIONS.length);
+    }
+  });
+
+  it('throws an AbortError without touching the engine when the signal is already aborted', async () => {
+    vi.mocked(wasmEngineModule.rebuildEngine).mockClear();
+
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      runEnginePerfSuite({
+        roundJson: JSON.stringify(round),
+        useLogit: false,
+        betAmount: 10000,
+        iterations: 3,
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+
+    expect(wasmEngineModule.rebuildEngine).not.toHaveBeenCalled();
+  });
+
+  it('every operation yields either a timing or a skip reason (no partial results)', async () => {
+    const results = await runEnginePerfSuite({
+      roundJson: JSON.stringify(round),
+      useLogit: false,
+      betAmount: 10000,
+      iterations: 2,
+    });
+    expect(PERF_BET_COUNT).toBe(10);
+    for (const result of results) {
+      expect(result.timing !== null || Boolean(result.skippedReason)).toBe(true);
+    }
+  });
+
+  // Leaves the shared engine in a known-good state for other test files.
+  it('restores the app engine to the current fixture round afterwards', () => {
+    wasmEngineModule.rebuildEngine(JSON.stringify(round), 10000, false);
+    expect(wasmEngineModule.wasmMakeMaxTerBets(10).bets.size).toBe(10);
+  });
+});

--- a/src/app/perf/wasmEnginePerf.ts
+++ b/src/app/perf/wasmEnginePerf.ts
@@ -1,0 +1,157 @@
+import { computePiratesBinary } from '../maths';
+import {
+  rebuildEngine,
+  wasmMakeBestGambitBets,
+  wasmMakeBustproofBets,
+  wasmMakeCrazyBets,
+  wasmMakeGambitBets,
+  wasmMakeMaxTerBets,
+  wasmMakeTenbetBets,
+  wasmMakeWinningGambitBets,
+} from '../wasmEngine';
+
+/** Number of bets every timed operation generates. Kept small on purpose - the
+ *  perf panel is about measuring per-operation cost, not sweeping bet counts. */
+export const PERF_BET_COUNT = 10;
+
+/** Per-operation timing captured by `timeOperation`. */
+export interface PerfTiming {
+  minMs: number;
+  maxMs: number;
+  avgMs: number;
+}
+
+/** Result of timing one engine operation. `timing` is null when the operation
+ *  was skipped (e.g. the round has no winners yet) - `skippedReason` explains why. */
+export interface EnginePerfResult {
+  operation: string;
+  timing: PerfTiming | null;
+  skippedReason?: string;
+}
+
+export interface RunEnginePerfOptions {
+  roundJson: string;
+  useLogit: boolean;
+  /** Bet amount the timed engine is built with (max-TER ranking). */
+  betAmount: number;
+  /** How many times to invoke each operation. */
+  iterations: number;
+  onProgress?: (done: number, total: number) => void;
+  signal?: AbortSignal;
+}
+
+/**
+ * Times `fn` over `iterations` invocations, reporting min/max/avg in ms.
+ * Uses performance.now() (sub-millisecond resolution) rather than Date.now().
+ */
+export function timeOperation(fn: () => void, iterations: number): PerfTiming {
+  let minMs = Number.POSITIVE_INFINITY;
+  let maxMs = 0;
+  let totalMs = 0;
+
+  for (let i = 0; i < iterations; i++) {
+    const start = window.performance.now();
+    fn();
+    const elapsed = window.performance.now() - start;
+    if (elapsed < minMs) {
+      minMs = elapsed;
+    }
+    if (elapsed > maxMs) {
+      maxMs = elapsed;
+    }
+    totalMs += elapsed;
+  }
+
+  return { minMs, maxMs, avgMs: totalMs / iterations };
+}
+
+/**
+ * The "default" gambit selection - pirate index 1 in every arena. `wasmMakeGambitBets`
+ * requires exactly one pirate per arena, so this is the simplest valid binary; it's
+ * also what a user gets when they pick pirate 1 on every row of the bet table.
+ */
+export function deriveDefaultGambitBinary(): number {
+  return computePiratesBinary([1, 1, 1, 1, 1]);
+}
+
+/**
+ * The "default" tenbet selection - pirate index 1 in the first three arenas. Tenbet
+ * accepts up to 3 pirates total, so this is the largest valid selection with the
+ * simplest shape (and matches the existing golden tests' `[1, 1, 1, 0, 0]` usage).
+ */
+export function deriveDefaultTenbetBinary(): number {
+  return computePiratesBinary([1, 1, 0, 0, 0]);
+}
+
+interface OpDef {
+  operation: string;
+  /**
+   * Probes whether the operation is applicable to this round WITHOUT timing.
+   * Returns a skip reason when it isn't (the engine's null-returning ops mean
+   * "not applicable" - no winners yet, or no positive arena for bustproof).
+   */
+  prepare?: () => string | null;
+  run: () => void;
+}
+
+/**
+ * Rebuilds the shared wasm engine for `roundJson` and times each bet-generation
+ * operation over `iterations` invocations. Runs chunked (one op per await tick)
+ * so a large iteration count can't freeze the UI, and aborts on `signal`.
+ *
+ * Note: this clobbers the app's engine instance - callers (the dev modal) are
+ * expected to rebuild it for their own round afterwards.
+ */
+export async function runEnginePerfSuite(opts: RunEnginePerfOptions): Promise<EnginePerfResult[]> {
+  if (opts.signal?.aborted) {
+    throw new DOMException('Engine perf run aborted', 'AbortError');
+  }
+
+  const results: EnginePerfResult[] = [];
+
+  rebuildEngine(opts.roundJson, opts.betAmount, opts.useLogit);
+  const gambitBinary = deriveDefaultGambitBinary();
+  const tenbetBinary = deriveDefaultTenbetBinary();
+
+  // rebuildEngine itself is not timed - the suite measures bet generation on a
+  // freshly built engine, and rebuilding in a loop would just time allocation.
+  const ops: OpDef[] = [
+    { operation: 'makeMaxTerBets', run: () => wasmMakeMaxTerBets(PERF_BET_COUNT) },
+    { operation: 'makeGambitBets', run: () => wasmMakeGambitBets(gambitBinary, PERF_BET_COUNT) },
+    {
+      operation: 'makeWinningGambitBets',
+      prepare: () => (wasmMakeWinningGambitBets(PERF_BET_COUNT) ? null : 'no winners yet'),
+      run: () => wasmMakeWinningGambitBets(PERF_BET_COUNT),
+    },
+    { operation: 'makeBestGambitBets', run: () => wasmMakeBestGambitBets(PERF_BET_COUNT) },
+    {
+      operation: 'makeBustproofBets',
+      prepare: () => (wasmMakeBustproofBets(PERF_BET_COUNT) ? null : 'no positive arena'),
+      run: () => wasmMakeBustproofBets(PERF_BET_COUNT),
+    },
+    { operation: 'makeCrazyBets', run: () => wasmMakeCrazyBets(PERF_BET_COUNT) },
+    { operation: 'makeTenbetBets', run: () => wasmMakeTenbetBets(tenbetBinary, PERF_BET_COUNT) },
+  ];
+
+  for (let i = 0; i < ops.length; i++) {
+    const op = ops[i]!;
+
+    if (opts.signal?.aborted) {
+      throw new DOMException('Engine perf run aborted', 'AbortError');
+    }
+
+    const skippedReason = op.prepare?.() ?? null;
+    if (skippedReason !== null) {
+      results.push({ operation: op.operation, timing: null, skippedReason });
+    } else {
+      results.push({ operation: op.operation, timing: timeOperation(op.run, opts.iterations) });
+    }
+
+    opts.onProgress?.(i + 1, ops.length);
+    // Yield to the event loop between operations so progress renders and the
+    // Cancel button can land (same idiom as runFullBacktest).
+    await new Promise<void>(resolve => setTimeout(resolve, 0));
+  }
+
+  return results;
+}

--- a/src/app/perf/wasmEnginePerf.ts
+++ b/src/app/perf/wasmEnginePerf.ts
@@ -40,29 +40,54 @@ export interface RunEnginePerfOptions {
   signal?: AbortSignal;
 }
 
+/** Each timed sample batches at least this many calls together (rather than
+ *  timing one call at a time) so its duration comfortably clears
+ *  performance.now()'s clamped resolution - a single bet-generation call is
+ *  fast enough that per-call timing quantizes straight to 0 in most browsers,
+ *  no matter how many iterations are run. */
+const MIN_BATCH_SIZE = 10;
+
+/** Caps the number of distinct timed samples, so a large iteration count
+ *  grows the batch size (for a steadier per-call reading) instead of just
+ *  adding more still-quantized samples. */
+const MAX_SAMPLES = 10;
+
 /**
- * Times `fn` over `iterations` invocations, reporting min/max/avg in ms.
- * Uses performance.now() (sub-millisecond resolution) rather than Date.now().
+ * Times `fn` over `iterations` invocations, reporting min/max/avg ms per call.
+ * Calls are grouped into batches of at least `MIN_BATCH_SIZE`; each batch's
+ * elapsed time is divided by its call count to get a per-call reading, which
+ * is far less prone to the timer-resolution quantization that per-call timing
+ * hits.
  */
 export function timeOperation(fn: () => void, iterations: number): PerfTiming {
+  const samples = Math.max(1, Math.min(MAX_SAMPLES, Math.floor(iterations / MIN_BATCH_SIZE)));
+  const batchSize = Math.floor(iterations / samples);
+  const remainder = iterations - batchSize * samples;
+
   let minMs = Number.POSITIVE_INFINITY;
   let maxMs = 0;
   let totalMs = 0;
+  let totalCalls = 0;
 
-  for (let i = 0; i < iterations; i++) {
+  for (let s = 0; s < samples; s++) {
+    const callsInSample = batchSize + (s < remainder ? 1 : 0);
     const start = window.performance.now();
-    fn();
-    const elapsed = window.performance.now() - start;
-    if (elapsed < minMs) {
-      minMs = elapsed;
+    for (let i = 0; i < callsInSample; i++) {
+      fn();
     }
-    if (elapsed > maxMs) {
-      maxMs = elapsed;
+    const elapsed = window.performance.now() - start;
+    const perCallMs = elapsed / callsInSample;
+    if (perCallMs < minMs) {
+      minMs = perCallMs;
+    }
+    if (perCallMs > maxMs) {
+      maxMs = perCallMs;
     }
     totalMs += elapsed;
+    totalCalls += callsInSample;
   }
 
-  return { minMs, maxMs, avgMs: totalMs / iterations };
+  return { minMs, maxMs, avgMs: totalMs / totalCalls };
 }
 
 /**


### PR DESCRIPTION
Times each wasm bet generator (max-TER, gambit, winning-gambit,
best-gambit, bustproof, crazy, tenbet) repeatedly on a chosen round and
reports min/avg/max ms per operation. Skips not-applicable operations
(no winners yet, no positive arena) with a reason, runs chunked with
cancel support, and restores the app's engine after each run.

The deriveDefaultGambitBinary/deriveDefaultTenbetBinary helpers are
exported for reuse by the upcoming all-strategies backtest.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>