### PR TITLE
Deploy to Cloudflare Pages only after CI and Playwright tests pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,13 @@ jobs:
         VITE_GIT_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       run: bun run build
 
+    - name: Upload Build Output
+      uses: actions/upload-artifact@v7
+      with:
+        name: build-output
+        path: build/
+        retention-days: 7
+
     - name: Upload Coverage
       if: github.event_name == 'pull_request'
       uses: codecov/codecov-action@v7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,61 @@
+name: Deploy to Cloudflare Pages
+
+# Deploys main to Cloudflare Pages only after the CI and Playwright Tests
+# workflows have both succeeded for the same push. workflow_run can't be
+# triggered by pull_request events, so this is a main-only deploy.
+on:
+  workflow_run:
+    workflows: ['CI', 'Playwright Tests']
+    types: [ completed ]
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare Pages
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+    - name: Check that all required workflows passed for this push
+      uses: actions/github-script@v9
+      with:
+        script: |
+          const run = context.payload.workflow_run;
+          const runs = await github.rest.actions.listWorkflowRunsForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            branch: 'main',
+            head_sha: run.head_sha,
+          });
+          const required = ['CI', 'Playwright Tests'];
+          for (const name of required) {
+            const match = runs.data.workflow_runs.find(r => r.name === name);
+            if (!match || match.conclusion !== 'success') {
+              const state = match ? `concluded ${match.conclusion}` : 'not found';
+              core.setFailed(`Workflow "${name}" for ${run.head_sha} did not pass (${state}). Skipping deploy.`);
+              return;
+            }
+          }
+
+    - name: Checkout
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ github.event.workflow_run.head_sha }}
+
+    - name: Download Build Output
+      uses: actions/download-artifact@v8
+      with:
+        name: build-output
+        path: build/
+        run-id: ${{ github.event.workflow_run.id }}
+
+    - name: Deploy to Cloudflare Pages
+      uses: cloudflare/wrangler-action@v4
+      with:
+        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        command: pages deploy build --project-name=foodclub


### PR DESCRIPTION
## Summary
- `ci.yml` now uploads the production build as a `build-output` artifact (retention 7 days) so another workflow can deploy it.
- New `deploy.yml` runs on `workflow_run` completion of the CI and Playwright Tests workflows. Before deploying it verifies via the API that **both** workflows succeeded for the same push on `main`; if either failed or was cancelled, no deploy happens.
- On success it downloads the build artifact from CI and deploys `build/` to Cloudflare Pages with wrangler (`pages deploy build --project-name=foodclub`).

This replaces the old in-CI `deploy` job (removed in #901) and guarantees tests gate the deploy: Cloudflare Pages goes last.