### PR TITLE
Grant actions:read permission so deploy can read the CI artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      actions: read
 
     steps:
     - name: Check that all required workflows passed for this push


### PR DESCRIPTION
## Summary
- Follow-up to #1028: the deploy job's token only had contents:read, which isn't enough for download-artifact to see artifacts via the Actions API. It fails with "Artifact not found" rather than a permissions error, which made this easy to miss.
- Confirmed by watching the fix from #1028 run on main: the correct CI run id was resolved and the artifact existed, but the download still failed until actions:read was granted.