### PR TITLE
Pass github-token to download-artifact for cross-run download

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,7 @@ jobs:
         name: build-output
         path: build/
         run-id: ${{ steps.check.outputs.ci_run_id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Deploy to Cloudflare Pages
       uses: cloudflare/wrangler-action@v4


### PR DESCRIPTION
## Summary
- Follow-up to #1028 and #1029: cross-run artifact downloads (run-id pointing at a different run than the current one) require an explicit github-token input on download-artifact - without it the request isn't authenticated and it reports "Artifact not found" even though the artifact exists and actions:read is granted.
- Confirmed by watching #1029 fail on main with exactly this symptom (correct run id, artifact present, still not found).