### PR TITLE
Install Bun before running wrangler-action in deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,11 @@ jobs:
         run-id: ${{ steps.check.outputs.ci_run_id }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: '1.4.0'
+
     - name: Deploy to Cloudflare Pages
       uses: cloudflare/wrangler-action@v4
       with:


### PR DESCRIPTION
## Summary
- Follow-up to #1030: wrangler-action auto-detects the package manager from the repo's lockfile (bun here) and shells out to it, but the deploy job never installed Bun, so the deploy step failed with "Unable to locate executable file: bun".
- Confirmed on main after #1030 merged: artifact download succeeded this time, but the deploy step itself then failed on this.