### PR TITLE
Fix Cloudflare Pages project name in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,4 +70,4 @@ jobs:
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        command: pages deploy build --project-name=foodclub
+        command: pages deploy build --project-name=neofoodclub


### PR DESCRIPTION
## Summary
- wrangler was failing with "The Pages project \"foodclub\" does not exist."
- Queried the account via the Cloudflare API: the project actually serving neofood.club is named neofoodclub, not foodclub.