### PR TITLE
Collapse legacy/logit comparison for model-independent strategies

### DIFF
--- a/src/app/components/charts/BacktestAmountSweepChart.tsx
+++ b/src/app/components/charts/BacktestAmountSweepChart.tsx
@@ -23,11 +23,14 @@ const LOGIT_COLOR = '#dd6b20';
 
 interface BacktestAmountSweepChartProps {
   points: AmountSweepPoint[];
+  /** When false, renders a single "Result" series (legacy and logit are identical) instead of both models. Defaults to true. */
+  showBothModels?: boolean;
 }
 
 const MODEL_FOR_LABEL: Record<string, (point: AmountSweepPoint) => ModelBacktestResult> = {
   'Legacy model': point => point.legacy,
   'Logit model': point => point.logit,
+  Result: point => point.legacy,
 };
 
 function modelForDataset(point: AmountSweepPoint, datasetLabel: string): ModelBacktestResult {
@@ -37,32 +40,44 @@ function modelForDataset(point: AmountSweepPoint, datasetLabel: string): ModelBa
 
 export function BacktestAmountSweepChart({
   points,
+  showBothModels = true,
 }: BacktestAmountSweepChartProps): React.JSX.Element {
   const { colorMode } = useColorMode();
   const isDarkLikeMode = colorMode !== 'light';
 
   const data = useMemo(
     () => ({
-      datasets: [
-        {
-          label: 'Legacy model',
-          data: points.map(p => ({ x: p.amount, y: p.legacy.roi * 100 })),
-          borderColor: LEGACY_COLOR,
-          backgroundColor: LEGACY_COLOR,
-          pointRadius: 3,
-          borderWidth: 2,
-        },
-        {
-          label: 'Logit model',
-          data: points.map(p => ({ x: p.amount, y: p.logit.roi * 100 })),
-          borderColor: LOGIT_COLOR,
-          backgroundColor: LOGIT_COLOR,
-          pointRadius: 3,
-          borderWidth: 2,
-        },
-      ],
+      datasets: showBothModels
+        ? [
+            {
+              label: 'Legacy model',
+              data: points.map(p => ({ x: p.amount, y: p.legacy.roi * 100 })),
+              borderColor: LEGACY_COLOR,
+              backgroundColor: LEGACY_COLOR,
+              pointRadius: 3,
+              borderWidth: 2,
+            },
+            {
+              label: 'Logit model',
+              data: points.map(p => ({ x: p.amount, y: p.logit.roi * 100 })),
+              borderColor: LOGIT_COLOR,
+              backgroundColor: LOGIT_COLOR,
+              pointRadius: 3,
+              borderWidth: 2,
+            },
+          ]
+        : [
+            {
+              label: 'Result',
+              data: points.map(p => ({ x: p.amount, y: p.legacy.roi * 100 })),
+              borderColor: LEGACY_COLOR,
+              backgroundColor: LEGACY_COLOR,
+              pointRadius: 3,
+              borderWidth: 2,
+            },
+          ],
     }),
-    [points],
+    [showBothModels, points],
   );
 
   const gridColor = isDarkLikeMode ? '#6272a4' : undefined;

--- a/src/app/components/charts/BacktestComparisonChart.tsx
+++ b/src/app/components/charts/BacktestComparisonChart.tsx
@@ -24,12 +24,15 @@ interface BacktestComparisonChartProps {
   rounds: number[];
   legacyCumulative: number[];
   logitCumulative: number[];
+  /** When false, renders a single "Result" line (legacy and logit are identical) instead of both models. Defaults to true. */
+  showBothModels?: boolean;
 }
 
 export function BacktestComparisonChart({
   rounds,
   legacyCumulative,
   logitCumulative,
+  showBothModels = true,
 }: BacktestComparisonChartProps): React.JSX.Element {
   const { colorMode } = useColorMode();
   const isDarkLikeMode = colorMode !== 'light';
@@ -45,26 +48,37 @@ export function BacktestComparisonChart({
 
   const data = useMemo(
     () => ({
-      datasets: [
-        {
-          label: 'Legacy model',
-          data: legacyPoints,
-          borderColor: LEGACY_COLOR,
-          backgroundColor: LEGACY_COLOR,
-          pointRadius: 0,
-          borderWidth: 2,
-        },
-        {
-          label: 'Logit model',
-          data: logitPoints,
-          borderColor: LOGIT_COLOR,
-          backgroundColor: LOGIT_COLOR,
-          pointRadius: 0,
-          borderWidth: 2,
-        },
-      ],
+      datasets: showBothModels
+        ? [
+            {
+              label: 'Legacy model',
+              data: legacyPoints,
+              borderColor: LEGACY_COLOR,
+              backgroundColor: LEGACY_COLOR,
+              pointRadius: 0,
+              borderWidth: 2,
+            },
+            {
+              label: 'Logit model',
+              data: logitPoints,
+              borderColor: LOGIT_COLOR,
+              backgroundColor: LOGIT_COLOR,
+              pointRadius: 0,
+              borderWidth: 2,
+            },
+          ]
+        : [
+            {
+              label: 'Result',
+              data: legacyPoints,
+              borderColor: LEGACY_COLOR,
+              backgroundColor: LEGACY_COLOR,
+              pointRadius: 0,
+              borderWidth: 2,
+            },
+          ],
     }),
-    [legacyPoints, logitPoints],
+    [showBothModels, legacyPoints, logitPoints],
   );
 
   const gridColor = isDarkLikeMode ? '#6272a4' : undefined;

--- a/src/app/components/modals/BacktestComparisonModal.tsx
+++ b/src/app/components/modals/BacktestComparisonModal.tsx
@@ -491,8 +491,8 @@ export const BacktestComparisonModal: React.FC<BacktestComparisonModalProps> = (
                         ) : (
                           <>
                             {STRATEGY_LABELS[strategy].name}&apos;s bet selection doesn&apos;t
-                            consult the probability model, so legacy and logit produce identical
-                            results here - shown for layout consistency with the other strategies.
+                            consult the probability model, so the legacy/logit choice doesn&apos;t
+                            apply here.
                           </>
                         )}
                       </Text>
@@ -577,28 +577,36 @@ export const BacktestComparisonModal: React.FC<BacktestComparisonModalProps> = (
                               {formatBacktestAmount(runState.betAmount ?? betAmount)}
                             </Code>
                           </Text>
-                          <SimpleGrid columns={{ base: 1, md: 2 }} gap={3}>
+                          {isModelDependentStrategy(runState.strategy) ? (
+                            <SimpleGrid columns={{ base: 1, md: 2 }} gap={3}>
+                              <ModelSummaryCard
+                                title="Legacy model"
+                                result={runState.result.legacy}
+                                isWinner={
+                                  runState.result.legacy.netProfit >=
+                                  runState.result.logit.netProfit
+                                }
+                              />
+                              <ModelSummaryCard
+                                title="Logit model"
+                                result={runState.result.logit}
+                                isWinner={
+                                  runState.result.logit.netProfit > runState.result.legacy.netProfit
+                                }
+                              />
+                            </SimpleGrid>
+                          ) : (
                             <ModelSummaryCard
-                              title="Legacy model"
+                              title="Result"
                               result={runState.result.legacy}
-                              isWinner={
-                                isModelDependentStrategy(runState.strategy) &&
-                                runState.result.legacy.netProfit >= runState.result.logit.netProfit
-                              }
+                              isWinner={false}
                             />
-                            <ModelSummaryCard
-                              title="Logit model"
-                              result={runState.result.logit}
-                              isWinner={
-                                isModelDependentStrategy(runState.strategy) &&
-                                runState.result.logit.netProfit > runState.result.legacy.netProfit
-                              }
-                            />
-                          </SimpleGrid>
+                          )}
                           <BacktestComparisonChart
                             rounds={runState.result.rounds}
                             legacyCumulative={runState.result.legacy.cumulativeNet}
                             logitCumulative={runState.result.logit.cumulativeNet}
+                            showBothModels={isModelDependentStrategy(runState.strategy)}
                           />
                         </Stack>
                       )}
@@ -721,7 +729,12 @@ export const BacktestComparisonModal: React.FC<BacktestComparisonModalProps> = (
                         </Text>
                       )}
 
-                      {sweepState.result && <BacktestAmountSweepChart points={sweepState.result} />}
+                      {sweepState.result && (
+                        <BacktestAmountSweepChart
+                          points={sweepState.result}
+                          showBothModels={isModelDependentStrategy(strategy)}
+                        />
+                      )}
                     </Stack>
                   </Tabs.Content>
                 </Tabs.Root>

--- a/src/app/components/modals/BetSimulatorModal.tsx
+++ b/src/app/components/modals/BetSimulatorModal.tsx
@@ -438,42 +438,45 @@ export const BetSimulatorModal: React.FC<{ isOpen: boolean; onClose: () => void 
                       </Code>
                     </Text>
 
-                    <HStack gap={3} flexWrap="wrap">
-                      <ModelCard
-                        title="Legacy model"
-                        result={state.result.legacy}
-                        isWinner={
-                          isModelDependentStrategy(state.strategy) &&
-                          state.result.legacy.netProfit >= state.result.logit.netProfit
-                        }
-                      />
-                      <ModelCard
-                        title="Logit model"
-                        result={state.result.logit}
-                        isWinner={
-                          isModelDependentStrategy(state.strategy) &&
-                          state.result.logit.netProfit > state.result.legacy.netProfit
-                        }
-                      />
-                    </HStack>
-
-                    {!isModelDependentStrategy(state.strategy) && (
-                      <Text fontSize="xs" color="fg.muted" fontStyle="italic">
-                        {STRATEGY_LABELS[state.strategy].name}&apos;s bet selection doesn&apos;t
-                        consult the probability model, so legacy and logit are identical here.
-                      </Text>
+                    {isModelDependentStrategy(state.strategy) ? (
+                      <HStack gap={3} flexWrap="wrap">
+                        <ModelCard
+                          title="Legacy model"
+                          result={state.result.legacy}
+                          isWinner={state.result.legacy.netProfit >= state.result.logit.netProfit}
+                        />
+                        <ModelCard
+                          title="Logit model"
+                          result={state.result.logit}
+                          isWinner={state.result.logit.netProfit > state.result.legacy.netProfit}
+                        />
+                      </HStack>
+                    ) : (
+                      <>
+                        <ModelCard title="Result" result={state.result.legacy} isWinner={false} />
+                        <Text fontSize="xs" color="fg.muted" fontStyle="italic">
+                          {STRATEGY_LABELS[state.strategy].name}&apos;s bet selection doesn&apos;t
+                          consult the probability model, so the legacy/logit choice doesn&apos;t
+                          apply here.
+                        </Text>
+                      </>
                     )}
 
                     <BacktestComparisonChart
                       rounds={state.result.rounds}
                       legacyCumulative={state.result.legacy.cumulativeNet}
                       logitCumulative={state.result.logit.cumulativeNet}
+                      showBothModels={isModelDependentStrategy(state.strategy)}
                     />
 
-                    <HStack gap={3} align="start" flexWrap="wrap">
-                      <ModelPayouts title="Legacy model" result={state.result.legacy} />
-                      <ModelPayouts title="Logit model" result={state.result.logit} />
-                    </HStack>
+                    {isModelDependentStrategy(state.strategy) ? (
+                      <HStack gap={3} align="start" flexWrap="wrap">
+                        <ModelPayouts title="Legacy model" result={state.result.legacy} />
+                        <ModelPayouts title="Logit model" result={state.result.logit} />
+                      </HStack>
+                    ) : (
+                      <ModelPayouts title="Result" result={state.result.legacy} />
+                    )}
                   </Stack>
                 )}
               </Stack>


### PR DESCRIPTION
## Summary
- Gambit, Winning Gambit, Crazy, and Bustproof never consult the probability model, so the dev-mode "Compare Bet Strategies" and "Bet Simulator" modals were showing two identical Legacy/Logit result panels and overlapping chart lines for them.
- These four strategies now render a single "Result" panel and chart line instead. Model-dependent strategies (Max-TER, General ER, Ten-bet, Best Gambit) are unaffected and still show the full Legacy vs Logit comparison, including the "Better" badge.
- No computation changes - `isModelDependentStrategy()` already avoided the redundant backtest run; this is purely a UI simplification.