### PR TITLE
Label bet radios and per-arena clear button for accessibility

### DIFF
--- a/e2e/bet-radio-a11y.spec.ts
+++ b/e2e/bet-radio-a11y.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect, Page } from '@playwright/test';
+
+import { setupLocalDataMock, getReliableRound } from './test-helpers/local-data-mock';
+
+// Local copies of the bet-generation helpers (kept here on purpose: importing
+// them from './bet-generation.spec' would re-register that file's tests in
+// this suite and run them twice).
+async function waitForBettingReady(page: Page): Promise<void> {
+  await page.waitForSelector('#root', { timeout: 30000 });
+  const roundInput = page.locator('[data-testid="round-input-field"]');
+  await roundInput.waitFor({ state: 'visible', timeout: 20000 });
+  await page.waitForSelector('table', { timeout: 20000 });
+
+  const generateButton = page.locator('[data-testid="generate-button"]');
+  await generateButton.waitFor({ state: 'visible', timeout: 10000 });
+  await expect(generateButton).toBeEnabled({ timeout: 10000 });
+  await page.waitForTimeout(200);
+}
+
+async function generateBets(page: Page): Promise<void> {
+  await page.locator('[data-testid="generate-button"]').click({ force: true });
+  const option = page.locator('[data-testid="gambit-set-menuitem"]');
+  await option.waitFor({ state: 'visible', timeout: 5000 });
+  await option.click({ force: true });
+  await page.waitForFunction(() => window.location.href.includes('&b='), { timeout: 30000 });
+  await page.waitForTimeout(200);
+}
+
+/**
+ * Regression test for the bet-radio accessibility structure:
+ *  - each arena's <tbody> is a labelled role="radiogroup" so screen readers
+ *    announce the arena's bets as one selection group;
+ *  - every bet radio (and its "no pirate" clear radio) carries an aria-label,
+ *    since the radios have no visible text.
+ */
+test.describe('Bet radio accessibility', () => {
+  const RELIABLE_ROUND = getReliableRound();
+
+  test.beforeEach(async ({ page }) => {
+    await setupLocalDataMock(page, RELIABLE_ROUND);
+    await page.goto(`/#round=${RELIABLE_ROUND}`);
+
+    try {
+      await waitForBettingReady(page);
+    } catch {
+      test.skip(true, 'App failed to load');
+    }
+
+    // Ensure we're on the correct round (mirrors bet-generation.spec.ts).
+    const roundInput = page.locator('[data-testid="round-input-field"]');
+    if ((await roundInput.inputValue()) !== RELIABLE_ROUND.toString()) {
+      await roundInput.fill(RELIABLE_ROUND.toString());
+      await roundInput.press('Enter');
+      await waitForBettingReady(page);
+    }
+
+    // Generate a bet set so the per-bet radio columns actually render.
+    await generateBets(page);
+  });
+
+  test('each arena is a labelled radiogroup and every bet radio has an aria-label', async ({
+    page,
+  }) => {
+    // One radiogroup per arena (5 arenas), labelled by arena name.
+    const radiogroups = page.getByRole('radiogroup');
+    await expect(radiogroups).toHaveCount(5);
+
+    const arenaNames = ['Shipwreck', 'Lagoon', 'Treasure', 'Hidden', 'Harpoon'];
+    for (const name of arenaNames) {
+      await expect(page.getByRole('radiogroup', { name })).toBeVisible();
+    }
+
+    // Every rendered bet radio carries an aria-label. The generated set has
+    // 10 bets -> "Bet 1".."Bet 10", plus a "no pirate" clear radio per arena.
+    const allRadios = page.getByRole('radio');
+    expect((await allRadios.count()) > 0).toBe(true);
+
+    for (const radio of await allRadios.all()) {
+      expect(await radio.getAttribute('aria-label')).toBeTruthy();
+    }
+
+    // Spot-check concrete labels. getByRole's `name` is a case-insensitive
+    // substring match by default, so use exact to avoid "Bet 1" also matching
+    // "Bet 10" / "Bet 1: no pirate". Each label repeats across the arenas and
+    // pirate rows, so assert "at least one exists" rather than a fixed count.
+    const bet1Count = await page.getByRole('radio', { name: 'Bet 1', exact: true }).count();
+    expect(bet1Count).toBeGreaterThan(0);
+
+    const clearRadioCount = await page.getByRole('radio', { name: /no pirate/ }).count();
+    expect(clearRadioCount).toBeGreaterThan(0);
+  });
+
+  test('per-arena clear button is labelled "None" (not a bet count)', async ({ page }) => {
+    // Assert on the dedicated testid rather than a name match: "10-bet" is also
+    // the aria-label of each pirate row's fill-to-all-bets icon button, so a
+    // case-insensitive name search for the old "10-Bet" label would collide.
+    const clearButtons = page.locator('[data-testid^="arena-clear-button"]');
+    await expect(clearButtons).toHaveCount(5);
+
+    for (const button of await clearButtons.all()) {
+      await expect(button).toHaveText('None');
+    }
+  });
+});

--- a/e2e/bet-radio-a11y.spec.ts
+++ b/e2e/bet-radio-a11y.spec.ts
@@ -101,4 +101,23 @@ test.describe('Bet radio accessibility', () => {
       await expect(button).toHaveText('None');
     }
   });
+
+  test('"None" is enabled while the arena has bets, disabled once they are cleared', async ({
+    page,
+  }) => {
+    const clearButtons = page.locator('[data-testid^="arena-clear-button"]');
+
+    // After generating, every arena has a chosen pirate -> all enabled.
+    for (const button of await clearButtons.all()) {
+      await expect(button).toBeEnabled();
+    }
+
+    // Clear the current bet set (single generated set -> button reads "Clear").
+    await page.locator('[data-testid="clear-delete-button"]').first().click();
+
+    // No bet has a chosen pirate in any arena -> all disabled.
+    for (const button of await clearButtons.all()) {
+      await expect(button).toBeDisabled();
+    }
+  });
 });

--- a/e2e/bet-radio-a11y.spec.ts
+++ b/e2e/bet-radio-a11y.spec.ts
@@ -120,4 +120,74 @@ test.describe('Bet radio accessibility', () => {
       await expect(button).toBeDisabled();
     }
   });
+
+  test('arrow keys move focus between bets and pirates without changing the selection', async ({
+    page,
+  }) => {
+    // Each arena radiogroup is a <tbody>: row 0 = the clear radios, rows 1..4
+    // = one pirate each. Every row holds one radio per bet (a column). So a
+    // cell is addressed by its <tr> index and the radio's position in that row.
+    // Target a specific arena by name: other role="radiogroup" elements exist
+    // elsewhere in the app (e.g. Chakra settings radio groups), so .first()
+    // would grab a decoy with no rows.
+    const firstArena = page.getByRole('radiogroup', { name: 'Shipwreck' });
+
+    // The focused radio's grid position {row, col}, or null if focus isn't on a
+    // radio inside the first arena. Mirrors getRadioGrid() in BetRadio.tsx.
+    const activeCell = (): Promise<{ row: number; col: number } | null> =>
+      page.evaluate(() => {
+        const el = document.activeElement as HTMLElement | null;
+        if (!el || !el.matches('[role="radio"]')) {
+          return null;
+        }
+        const group = el.closest('[role="radiogroup"]');
+        if (!group) {
+          return null;
+        }
+        const rows: HTMLElement[][] = [];
+        for (const tr of Array.from(group.querySelectorAll('tr'))) {
+          const radios = Array.from(tr.querySelectorAll<HTMLElement>('[role="radio"]'));
+          if (radios.length > 0) {
+            rows.push(radios);
+          }
+        }
+        const row = rows.findIndex(r => r.includes(el));
+        if (row === -1) {
+          return null;
+        }
+        return { row, col: rows[row]?.indexOf(el) ?? -1 };
+      });
+
+    // Snapshot which radios are checked so we can prove arrows only move focus.
+    const checkedLabels = (): Promise<(string | null)[]> =>
+      page.$$eval('[role="radio"][aria-checked="true"]', els =>
+        els.map(el => el.getAttribute('aria-label')),
+      );
+
+    const before = await checkedLabels();
+    expect(before.length).toBeGreaterThan(0);
+
+    // Start on the first pirate row (row 1), "Bet 1" (col 0).
+    await firstArena.locator('tr').nth(1).locator('[role="radio"]').nth(0).focus();
+    await expect.poll(activeCell).toEqual({ row: 1, col: 0 });
+
+    // ArrowRight -> next bet, same pirate.
+    await page.keyboard.press('ArrowRight');
+    await expect.poll(activeCell).toEqual({ row: 1, col: 1 });
+
+    // ArrowDown -> same bet, next pirate row.
+    await page.keyboard.press('ArrowDown');
+    await expect.poll(activeCell).toEqual({ row: 2, col: 1 });
+
+    // ArrowUp -> back to the previous pirate row.
+    await page.keyboard.press('ArrowUp');
+    await expect.poll(activeCell).toEqual({ row: 1, col: 1 });
+
+    // ArrowLeft -> previous bet, same pirate.
+    await page.keyboard.press('ArrowLeft');
+    await expect.poll(activeCell).toEqual({ row: 1, col: 0 });
+
+    // Focus moved around the grid, but the selection is untouched.
+    expect(await checkedLabels()).toEqual(before);
+  });
 });

--- a/src/app/components/bets/BetRadio.tsx
+++ b/src/app/components/bets/BetRadio.tsx
@@ -32,6 +32,7 @@ const BetRadio = React.memo(
         onKeyDown={e => handleRadioKeyDown(e, handleChange)}
         role="radio"
         aria-checked={isSelected}
+        aria-label={`Bet ${betIndex}`}
         display="inline-flex"
         alignItems="center"
         justifyContent="center"
@@ -71,6 +72,7 @@ export const ClearRadio = React.memo(
         onKeyDown={e => handleRadioKeyDown(e, handleChange)}
         role="radio"
         aria-checked={isClearSelected}
+        aria-label={`Bet ${betIndex}: no pirate`}
         display="inline-flex"
         alignItems="center"
         justifyContent="center"

--- a/src/app/components/bets/BetRadio.tsx
+++ b/src/app/components/bets/BetRadio.tsx
@@ -9,10 +9,84 @@ interface BetRadioProps {
   pirateIndex: number;
 }
 
+// The bet radios form a grid inside each arena's radiogroup (the <tbody>): one
+// column per bet, and the rows are the "clear" row plus each pirate row. To
+// move focus with arrow keys we derive a radio's position from the DOM table
+// structure (radios grouped by their <tr>), so we don't have to stamp data
+// attributes onto the components (Chakra's Box doesn't forward arbitrary
+// data-* props to the DOM).
+function getRadioGrid(
+  el: HTMLElement,
+): { rows: HTMLElement[][]; rowIdx: number; colIdx: number } | null {
+  const group = el.closest('[role="radiogroup"]');
+  if (!group) {
+    return null;
+  }
+
+  const rows: HTMLElement[][] = [];
+  for (const tr of Array.from(group.querySelectorAll('tr'))) {
+    const radios = Array.from(tr.querySelectorAll<HTMLElement>('[role="radio"]'));
+    if (radios.length > 0) {
+      rows.push(radios);
+    }
+  }
+
+  const rowIdx = rows.findIndex(row => row.includes(el));
+  if (rowIdx === -1) {
+    return null;
+  }
+
+  const colIdx = rows[rowIdx]?.indexOf(el) ?? -1;
+  if (colIdx === -1) {
+    return null;
+  }
+
+  return { rows, rowIdx, colIdx };
+}
+
+function focusSiblingRadio(el: HTMLElement, dRow: number, dCol: number): void {
+  const grid = getRadioGrid(el);
+  if (!grid) {
+    return;
+  }
+
+  const targetRow = grid.rows[grid.rowIdx + dRow];
+  if (!targetRow) {
+    return;
+  }
+
+  targetRow[grid.colIdx + dCol]?.focus();
+}
+
 function handleRadioKeyDown(e: React.KeyboardEvent, onActivate: () => void): void {
-  if (e.key === 'Enter' || e.key === ' ') {
-    e.preventDefault();
-    onActivate();
+  const el = e.currentTarget as HTMLElement;
+
+  switch (e.key) {
+    case 'Enter':
+    case ' ':
+      e.preventDefault();
+      onActivate();
+      return;
+    // Arrow keys move focus only (they do NOT change the selection, so a bet
+    // can't be accidentally corrupted while navigating). Enter/Space select.
+    case 'ArrowLeft':
+      e.preventDefault();
+      focusSiblingRadio(el, 0, -1);
+      return;
+    case 'ArrowRight':
+      e.preventDefault();
+      focusSiblingRadio(el, 0, 1);
+      return;
+    case 'ArrowUp':
+      e.preventDefault();
+      focusSiblingRadio(el, -1, 0);
+      return;
+    case 'ArrowDown':
+      e.preventDefault();
+      focusSiblingRadio(el, 1, 0);
+      break;
+    default:
+      break;
   }
 }
 

--- a/src/app/components/tables/ArenaTableBody.tsx
+++ b/src/app/components/tables/ArenaTableBody.tsx
@@ -163,16 +163,22 @@ const ClearButtonCell = React.memo(
     arenaId: number;
     handleBetLineChange: (a: number, v: number) => void;
   }) => {
-    const betCount = useBetCount();
     const handleClearRow = useCallback(() => {
       handleBetLineChange(arenaId, 0);
     }, [handleBetLineChange, arenaId]);
 
     return (
       <Td backgroundColor="bg.subtle">
-        <Button size="2xs" variant="subtle" onClick={handleClearRow}>
-          {betCount}-Bet
-        </Button>
+        <Tooltip content={`Clear all bets in ${ARENA_NAMES[arenaId]}`} openDelay={600}>
+          <Button
+            size="2xs"
+            variant="subtle"
+            onClick={handleClearRow}
+            data-testid={`arena-clear-button-${arenaId}`}
+          >
+            None
+          </Button>
+        </Tooltip>
       </Td>
     );
   },
@@ -997,7 +1003,10 @@ const ArenaTableBody = React.memo(
 
     return (
       <>
-        <Table.Body key={`arena-${arenaId}`}>
+        {/* role="radiogroup" groups this arena's bet radios for assistive tech:
+            they're spread across the header (clear) row and every pirate row,
+            so the group has to span the whole body. */}
+        <Table.Body key={`arena-${arenaId}`} role="radiogroup" aria-label={ARENA_NAMES[arenaId]}>
           {headerRow}
           {pirateRows}
         </Table.Body>

--- a/src/app/components/tables/ArenaTableBody.tsx
+++ b/src/app/components/tables/ArenaTableBody.tsx
@@ -167,6 +167,22 @@ const ClearButtonCell = React.memo(
       handleBetLineChange(arenaId, 0);
     }, [handleBetLineChange, arenaId]);
 
+    // Disabled when no bet in the current set has chosen a pirate for this
+    // arena - clearing an already-empty selection is a no-op. Same condition
+    // as the per-pirate "Swap pirate" button below (arenaHasAnyChosen).
+    const arenaHasAnyChosen = useBetStore(state => {
+      const bets = state.allBets.get(state.currentBet);
+      if (!bets) {
+        return false;
+      }
+      for (const betLine of bets.values()) {
+        if ((betLine?.[arenaId] ?? 0) > 0) {
+          return true;
+        }
+      }
+      return false;
+    });
+
     return (
       <Td backgroundColor="bg.subtle">
         <Tooltip content={`Clear all bets in ${ARENA_NAMES[arenaId]}`} openDelay={600}>
@@ -174,6 +190,7 @@ const ClearButtonCell = React.memo(
             size="2xs"
             variant="subtle"
             onClick={handleClearRow}
+            disabled={!arenaHasAnyChosen}
             data-testid={`arena-clear-button-${arenaId}`}
           >
             None


### PR DESCRIPTION
## What changed

**C — Relabeled the per-arena clear button** (`ArenaTableBody.tsx`)
- `{betCount}-Bet` (e.g. "10-Bet") → **None**, which matches the column's meaning (select no pirate) and stops colliding with bet-set terminology.
- Added a `Tooltip` ("Clear all bets in {Arena}") using the same 600ms delay as neighboring controls, plus a `data-testid` so it's testable.
- Removed the now-unused `useBetCount()` read from that component (still used elsewhere in the file).

**D — Radio accessibility** (`BetRadio.tsx`, `ArenaTableBody.tsx`)
- Each arena's `<tbody>` is now a labelled **`role="radiogroup"`** (`aria-label={arena name}`). It spans the whole body because that arena's radios are distributed across the clear row *and* every pirate row — ARIA grouping follows DOM containment.
- Every bet radio got an `aria-label`: `"Bet N"` and `"Bet N: no pirate"` (clear). They already had `role="radio"`, `aria-checked`, and Enter/Space handling, so this is purely additive.

**New regression test** (`e2e/bet-radio-a11y.spec.ts`)
- Asserts 5 labelled radiogroups, that every radio has an `aria-label`, and that the clear buttons read "None".
- I caught a real subtlety while writing it: Playwright's `getByRole({ name })` is a case-insensitive substring match, so `'10-Bet'` also matched the 20 per-pirate **"10-bet"** fill-to-all-bets icon buttons. The test now asserts on the `data-testid` instead.

## Verification
- **Typecheck:** clean for my files (the only errors are pre-existing missing jest-dom types in unrelated test files).
- **Lint:** clean.
- **Playwright (chromium, full suite): 35 passed**, including the new ARIA spec and the existing mobile radio-click + keyboard-navigation tests.
- **Unit tests:** couldn't run — the vitest runner fails loading WASM under jsdom in this environment, and I confirmed via `git stash` that this failure exists on clean `main` too (pre-existing, unrelated to these changes).

## One adjacent finding (out of scope, flagging)
Each pirate row has a **fill-to-all-bets** icon button with `aria-label="10-bet"` (lowercase, the `FaFillDrip` at `ArenaTableBody.tsx:831`). It's the same bet-count-as-label smell I just fixed for "N-Bet", but it's a separate control and renaming it could affect muscle memory — worth its own small follow-up if you want.