### PR TITLE
Add setting for sticky place-bet buttons

### DIFF
--- a/src/app/components/TableSettings/StickyPlaceBetButtonsToggle.tsx
+++ b/src/app/components/TableSettings/StickyPlaceBetButtonsToggle.tsx
@@ -1,0 +1,37 @@
+import { memo, useMemo, useCallback } from 'react';
+import { FaThumbtack } from 'react-icons/fa6';
+import Cookies from 'universal-cookie';
+
+import { useStickyPlaceBetButtons, useSetStickyPlaceBetButtons } from '../../stores';
+
+import SettingsSwitch from './SettingsSwitch';
+
+const StickyPlaceBetButtonsToggle = memo(() => {
+  const stickyPlaceBetButtons = useStickyPlaceBetButtons();
+  const setStickyPlaceBetButtons = useSetStickyPlaceBetButtons();
+
+  const cookies = useMemo(() => new Cookies(), []);
+
+  const persistStickyPlaceBetButtonsPreference = useCallback((): void => {
+    const newValue = !stickyPlaceBetButtons;
+    cookies.set('stickyPlaceBetButtons', newValue);
+    setStickyPlaceBetButtons(newValue);
+  }, [stickyPlaceBetButtons, cookies, setStickyPlaceBetButtons]);
+
+  const tooltipLabel = 'Sticky Place Bet Buttons';
+
+  return (
+    <SettingsSwitch
+      icon={FaThumbtack}
+      label={tooltipLabel}
+      colorPalette="nfc-blue"
+      checked={stickyPlaceBetButtons ?? false}
+      onChange={persistStickyPlaceBetButtonsPreference}
+      tooltipText="Keep the Submit column pinned to the right edge of the table while scrolling horizontally."
+    />
+  );
+});
+
+StickyPlaceBetButtonsToggle.displayName = 'StickyPlaceBetButtonsToggle';
+
+export default StickyPlaceBetButtonsToggle;

--- a/src/app/components/tables/PayoutTable.tsx
+++ b/src/app/components/tables/PayoutTable.tsx
@@ -35,6 +35,7 @@ import {
   useCustomOddsMode,
   useRoundStore,
   useBetProbabilities,
+  useStickyPlaceBetButtons,
 } from '../../stores';
 import { displayAsPercent, displayAsPercentSmart, getMaxSmartPercentDecimals } from '../../util';
 import BetAmountInput from '../bets/BetAmountInput';
@@ -181,6 +182,7 @@ const PayoutTableRow = React.memo(
     const winningBetBinary = useWinningBetBinary();
     const currentBet = useCurrentBet();
     const amountOfBets = useBetCount();
+    const stickyPlaceBetButtons = useStickyPlaceBetButtons();
 
     const betAmount = useSpecificBetAmount(betIndex + 1);
     const currentBetLine = useBetLineSpecific(betIndex + 1);
@@ -379,7 +381,7 @@ const PayoutTableRow = React.memo(
             />
           );
         })}
-        <Td {...stickySubmitColumnProps}>
+        <Td {...(stickyPlaceBetButtons ? stickySubmitColumnProps : {})}>
           <PlaceThisBetButton bet={currentBetLine} betNum={betIndex + 1} />
         </Td>
       </Table.Row>
@@ -394,6 +396,7 @@ const PayoutTable = React.memo((): React.ReactElement => {
 
   const calculated = useCalculationsStatus();
   const winningBetBinary = useWinningBetBinary();
+  const stickyPlaceBetButtons = useStickyPlaceBetButtons();
 
   // Use individual hooks instead of object selector to avoid infinite loops
   const totalBetAmounts = useTotalBetAmounts();
@@ -501,7 +504,9 @@ const PayoutTable = React.memo((): React.ReactElement => {
           <Table.ColumnHeader minW="5rem">Treasure</Table.ColumnHeader>
           <Table.ColumnHeader minW="5rem">Hidden</Table.ColumnHeader>
           <Table.ColumnHeader minW="5rem">Harpoon</Table.ColumnHeader>
-          <Table.ColumnHeader {...stickySubmitHeaderProps}>Submit</Table.ColumnHeader>
+          <Table.ColumnHeader {...(stickyPlaceBetButtons ? stickySubmitHeaderProps : {})}>
+            Submit
+          </Table.ColumnHeader>
         </Table.Row>
       </Table.Header>
 
@@ -553,7 +558,7 @@ const PayoutTable = React.memo((): React.ReactElement => {
               <Table.ColumnHeader />
               <Table.ColumnHeader />
               <Table.ColumnHeader />
-              <Table.ColumnHeader {...stickySubmitColumnProps} />
+              <Table.ColumnHeader {...(stickyPlaceBetButtons ? stickySubmitColumnProps : {})} />
             </Table.Row>
           </Table.Body>
         </>

--- a/src/app/components/views/EditBets.tsx
+++ b/src/app/components/views/EditBets.tsx
@@ -43,6 +43,7 @@ import ColorModeToggle from '../TableSettings/ColorModeToggle';
 import CopyDomainToggle from '../TableSettings/CopyDomainToggle';
 import Extras from '../TableSettings/Extras';
 import LogitModelToggle from '../TableSettings/LogitModelToggle';
+import StickyPlaceBetButtonsToggle from '../TableSettings/StickyPlaceBetButtonsToggle';
 import TableModes from '../TableSettings/TableModes';
 
 import BetSetsPanel from './BetSetsPanel';
@@ -357,6 +358,8 @@ export default React.memo(function EditBets(): React.ReactElement {
                     <LogitModelToggle />
 
                     <CopyDomainToggle />
+
+                    <StickyPlaceBetButtonsToggle />
 
                     <Extras />
 

--- a/src/app/stores/index.ts
+++ b/src/app/stores/index.ts
@@ -125,6 +125,8 @@ export const useTableMode = (): string => useRoundStore(state => state.tableMode
 export const useBetSetPosition = (): BetSetPosition => useRoundStore(state => state.betSetPosition);
 export const useViewMode = (): boolean => useRoundStore(state => state.viewMode);
 export const useUseWebDomain = (): boolean => useRoundStore(state => state.useWebDomain);
+export const useStickyPlaceBetButtons = (): boolean =>
+  useRoundStore(state => state.stickyPlaceBetButtons);
 export const useBigBrain = (): boolean => useRoundStore(state => state.bigBrain);
 export const useFaDetails = (): boolean =>
   useRoundStore(state => state.faDetails && state.bigBrain);
@@ -149,6 +151,8 @@ export const useSetViewMode = (): ((viewMode: boolean) => void) =>
   useRoundStore(state => state.setViewMode);
 export const useSetUseWebDomain = (): ((useWebDomain: boolean) => void) =>
   useRoundStore(state => state.setUseWebDomain);
+export const useSetStickyPlaceBetButtons = (): ((stickyPlaceBetButtons: boolean) => void) =>
+  useRoundStore(state => state.setStickyPlaceBetButtons);
 export const useToggleBigBrain = (): (() => void) => useRoundStore(state => state.toggleBigBrain);
 export const useToggleFaDetails = (): (() => void) => useRoundStore(state => state.toggleFaDetails);
 export const useToggleOddsTimeline = (): (() => void) =>

--- a/src/app/stores/roundStore.ts
+++ b/src/app/stores/roundStore.ts
@@ -12,6 +12,7 @@ import {
   parseBetUrl,
   getTableMode,
   getUseWebDomain,
+  getStickyPlaceBetButtons,
   getUseLogitModel,
   anyBetsExist,
   getBigBrainMode,
@@ -98,6 +99,7 @@ interface RoundStore {
   betSetPosition: BetSetPosition;
   viewMode: boolean;
   useWebDomain: boolean;
+  stickyPlaceBetButtons: boolean;
   bigBrain: boolean;
   faDetails: boolean;
   customOddsMode: boolean;
@@ -125,6 +127,7 @@ interface RoundStore {
   setBetSetPosition: (position: BetSetPosition) => void;
   setViewMode: (viewMode: boolean) => void;
   setUseWebDomain: (useWebDomain: boolean) => void;
+  setStickyPlaceBetButtons: (stickyPlaceBetButtons: boolean) => void;
   toggleBigBrain: () => void;
   toggleFaDetails: () => void;
   toggleOddsTimeline: () => void;
@@ -164,6 +167,7 @@ export const useRoundStore = create<RoundStore>()(
     betSetPosition: getBetSetPosition(),
     viewMode: false,
     useWebDomain: getUseWebDomain(),
+    stickyPlaceBetButtons: getStickyPlaceBetButtons(),
     bigBrain: getBigBrainMode(),
     faDetails: getFaDetailsMode(),
     customOddsMode: getCustomOddsMode(),
@@ -313,6 +317,8 @@ export const useRoundStore = create<RoundStore>()(
     setBetSetPosition: (position: BetSetPosition): void => set({ betSetPosition: position }),
     setViewMode: (viewMode: boolean): void => set({ viewMode }),
     setUseWebDomain: (useWebDomain: boolean): void => set({ useWebDomain }),
+    setStickyPlaceBetButtons: (stickyPlaceBetButtons: boolean): void =>
+      set({ stickyPlaceBetButtons }),
 
     setMaxBet: (maxBet: number): void => {
       set({ maxBet });

--- a/src/app/util.ts
+++ b/src/app/util.ts
@@ -301,6 +301,10 @@ export function getUseWebDomain(): boolean {
   return getBooleanCookie('useWebDomain');
 }
 
+export function getStickyPlaceBetButtons(): boolean {
+  return getBooleanCookie('stickyPlaceBetButtons', true);
+}
+
 export function getMaxBetLocked(): boolean {
   return getBooleanCookie('maxBetLocked');
 }


### PR DESCRIPTION
## Summary
- The Submit column (place-bet buttons) has always been sticky to the right edge of the payout table during horizontal scroll.
- Adds a "Sticky Place Bet Buttons" toggle in the Settings accordion (default on, preserving current behavior) that lets users disable this.
- Follows the existing useWebDomain cookie-backed boolean setting pattern.