### PR TITLE
Add "New" indicator to Sticky Place Bet Buttons setting

### DIFF
--- a/src/app/components/TableSettings/SettingsRow.tsx
+++ b/src/app/components/TableSettings/SettingsRow.tsx
@@ -6,7 +6,7 @@ import { Switch } from '@/components/ui/switch';
 
 interface SettingsRowProps {
   icon: React.ElementType;
-  label: string;
+  label: ReactNode;
   colorPalette: string;
   isChecked: boolean;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;

--- a/src/app/components/TableSettings/SettingsSwitch.tsx
+++ b/src/app/components/TableSettings/SettingsSwitch.tsx
@@ -1,10 +1,10 @@
-import React, { ChangeEvent, MouseEvent } from 'react';
+import React, { ChangeEvent, MouseEvent, ReactNode } from 'react';
 
 import SettingsRow from './SettingsRow';
 
 interface SwitchBoxProps {
   icon: React.ElementType;
-  label: string;
+  label: ReactNode;
   colorPalette: string;
   checked: boolean;
   onChange: (e: ChangeEvent<HTMLInputElement> | MouseEvent<HTMLDivElement>) => void;

--- a/src/app/components/TableSettings/StickyPlaceBetButtonsToggle.tsx
+++ b/src/app/components/TableSettings/StickyPlaceBetButtonsToggle.tsx
@@ -1,3 +1,4 @@
+import { Badge, HStack, Text } from '@chakra-ui/react';
 import { memo, useMemo, useCallback } from 'react';
 import { FaThumbtack } from 'react-icons/fa6';
 import Cookies from 'universal-cookie';
@@ -18,12 +19,17 @@ const StickyPlaceBetButtonsToggle = memo(() => {
     setStickyPlaceBetButtons(newValue);
   }, [stickyPlaceBetButtons, cookies, setStickyPlaceBetButtons]);
 
-  const tooltipLabel = 'Sticky Place Bet Buttons';
-
   return (
     <SettingsSwitch
       icon={FaThumbtack}
-      label={tooltipLabel}
+      label={
+        <HStack gap={2}>
+          <Text>Sticky Place Bet Buttons</Text>
+          <Badge colorPalette="cyan" variant="subtle" size="sm" rounded="full">
+            New
+          </Badge>
+        </HStack>
+      }
       colorPalette="nfc-blue"
       checked={stickyPlaceBetButtons ?? false}
       onChange={persistStickyPlaceBetButtonsPreference}


### PR DESCRIPTION
## Summary
- Add the same cyan "New" badge treatment used for the Bet Generation Max Bet setting (#998) to the recently-added Sticky Place Bet Buttons toggle (#1049).
- Widen `SettingsRow`/`SettingsSwitch`'s `label` prop from `string` to `ReactNode` so the badge can be composed into the label, same as was done for `SegmentedSettingsRow` in #998.