### PR TITLE
Show full precision in probability tooltips

### DIFF
--- a/src/app/components/charts/PayoutCharts.tsx
+++ b/src/app/components/charts/PayoutCharts.tsx
@@ -363,7 +363,7 @@ const PayoutCharts: React.FC = React.memo(() => {
                     persistKey={`${persistPrefix}-probability`}
                   />
                 }
-                content={displayAsPercentSmart(dataObj.probability)}
+                content={displayAsPercent(dataObj.probability)}
               />
             </Table.Cell>
             <Table.Cell textAlign="end">

--- a/src/app/components/tables/PayoutTable.tsx
+++ b/src/app/components/tables/PayoutTable.tsx
@@ -37,7 +37,7 @@ import {
   useBetProbabilities,
   useStickyPlaceBetButtons,
 } from '../../stores';
-import { displayAsPercent, displayAsPercentSmart, getMaxSmartPercentDecimals } from '../../util';
+import { displayAsPercent, getMaxSmartPercentDecimals } from '../../util';
 import BetAmountInput from '../bets/BetAmountInput';
 import PlaceThisBetButton from '../bets/PlaceThisBetButton';
 import AnimatedNumber from '../ui/AnimatedNumber';
@@ -206,7 +206,7 @@ const PayoutTableRow = React.memo(
             format={v => displayAsPercent(v, probabilityDecimals)}
           />
         ),
-        label: displayAsPercentSmart(probabilities),
+        label: displayAsPercent(probabilities),
       }),
       [probabilities, probabilityDecimals],
     );


### PR DESCRIPTION
## Summary
- The probability tooltip in the per-bet payout table and the payout charts modal rounded to a computed number of decimals via `displayAsPercentSmart`. Switched both to `displayAsPercent` with no decimals argument, which returns the raw, unrounded percentage - matching how the adjacent expected ratio tooltip already shows its full precision value (`er.toString()`).
- Verified locally: probability tooltip in the payout table now shows e.g. `11.126278409090991%` instead of `11.126%`, and the payout charts probability column tooltip shows `44.070506465123295%` instead of `44.071%`.